### PR TITLE
chore/bump node engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "Documentation"
   ],
   "engines": {
-    "node": "^18.12.1"
+    "node": "^18.20.0"
   },
   "scripts": {
     "clean": "rimraf public .greenwood storybook-static",


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

Forgot to bump this in #45

## Summary of Changes

1. bump Node engines to `^18.20.0` to align with minimum greenwood version
