### PR TITLE
bug/issue 59 apply semantic HTML to header social links list

### DIFF
--- a/src/components/header/header.js
+++ b/src/components/header/header.js
@@ -35,7 +35,7 @@ export default class Header extends HTMLElement {
               </li>
             </ul>
 
-            <div class="social-tray">
+            <ul class="social-tray">
               <li class="social-icon">
                 <a href="https://github.com/ProjectEvergreen/greenwood" title="GitHub">
                   ${githubIcon}
@@ -53,7 +53,7 @@ export default class Header extends HTMLElement {
                   ${twitterIcon}
                 </a>
               </li>
-            </div>
+            </ul>
 
             <div class="mobile-menu">
               ${mobileMenuIcon}

--- a/src/components/header/header.spec.js
+++ b/src/components/header/header.spec.js
@@ -62,7 +62,7 @@ describe("Components/Header", () => {
     });
 
     it("should have the expected desktop navigation links", () => {
-      const links = header.shadowRoot.querySelectorAll("nav ul:not(.mobile-menu-items) li a");
+      const links = header.shadowRoot.querySelectorAll("nav ul.nav-bar-menu li a");
 
       Array.from(links).forEach((link) => {
         const navItem = NAV.find(


### PR DESCRIPTION
replace div parent of li elements with ul to enhance page semantics

<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
Resolves #59
<!-- Include a link to the issue (e.g. Resolves #12).  If this is to document a Greenwood feature, please link that issue here. -->

## Summary of Changes

 Replace the div parent of li element with ul tags to improve page ranking

1. [x] Replace div with appropriate ul tag