### PR TITLE
enhancement/issue 30 apply bold font family to key home page headings

### DIFF
--- a/src/components/build-with-friends/build-with-friends.module.css
+++ b/src/components/build-with-friends/build-with-friends.module.css
@@ -4,8 +4,8 @@
 }
 
 .heading {
+  font-family: var(--font-primary-bold);
   font-size: var(--font-size-6);
-  font-weight: var(--font-weight-9);
 }
 
 .subHeading {
@@ -32,7 +32,6 @@
 
 .icon span {
   vertical-align: middle;
-  font-weight: var(--font-weight-9);
   display: inline-block;
 }
 

--- a/src/components/capabilities/capabilities.css
+++ b/src/components/capabilities/capabilities.css
@@ -9,6 +9,7 @@
 }
 
 .heading {
+  font-family: var(--font-primary-bold);
   font-size: var(--font-size-6);
 }
 

--- a/src/components/capabilities/capabilities.css
+++ b/src/components/capabilities/capabilities.css
@@ -41,8 +41,8 @@
 
 .section:hover strong,
 .active strong {
+  font-family: var(--font-primary-bold);
   color: var(--color-white);
-  font-weight: bold;
 }
 
 .active {
@@ -68,13 +68,13 @@
 
 .heading {
   font-size: var(--font-size-fluid-3);
-  font-weight: bold;
+  font-family: var(--font-primary-bold);
   margin: 0;
 }
 
 .capability-heading {
   font-size: var(--font-size-fluid-1);
-  font-weight: bold;
+  font-family: var(--font-primary-bold);
   margin: var(--size-px-1) 0;
   display: inline-block;
 }

--- a/src/components/get-started/get-started.module.css
+++ b/src/components/get-started/get-started.module.css
@@ -6,8 +6,8 @@
 }
 
 .heading {
+  font-family: var(--font-primary-bold);
   font-size: var(--font-size-5);
-  font-weight: var(--font-weight-9);
 }
 
 .snippet {

--- a/src/components/header/header.module.css
+++ b/src/components/header/header.module.css
@@ -48,10 +48,6 @@
   text-decoration: underline;
 }
 
-.navBarMenuItem:hover {
-  font-weight: bold;
-}
-
 .socialTray {
   display: flex;
   gap: var(--size-3);

--- a/src/components/hero-banner/hero-banner.module.css
+++ b/src/components/hero-banner/hero-banner.module.css
@@ -123,7 +123,8 @@
   }
 }
 
-@media (min-width: 1024px) {
+/* use 1025 as a quick tweak for iPad Pro breakpoint */
+@media (min-width: 1025px) {
   .ctaContainer {
     margin: 0 auto;
     text-align: left;

--- a/src/components/hero-banner/hero-banner.module.css
+++ b/src/components/hero-banner/hero-banner.module.css
@@ -13,6 +13,7 @@
 
 .headingEmphasis {
   font-size: var(--font-size-6);
+  font-family: var(--font-primary-bold);
   font-style: italic;
 }
 

--- a/src/components/hero-banner/hero-banner.module.css
+++ b/src/components/hero-banner/hero-banner.module.css
@@ -5,15 +5,14 @@
 }
 
 .heading {
-  font-size: var(--font-size-7);
-  font-weight: var(--font-weight-7);
+  font-family: var(--font-primary-bold);
+  font-size: var(--font-size-6);
   margin-block-start: 0;
   margin-block-end: 0;
 }
 
 .headingEmphasis {
-  font-size: var(--font-size-7);
-  font-weight: var(--font-weight-7);
+  font-size: var(--font-size-6);
   font-style: italic;
 }
 
@@ -104,6 +103,11 @@
 }
 
 @media (min-width: 768px) {
+  .heading,
+  .headingEmphasis {
+    font-size: var(--font-size-7);
+  }
+
   .buttonBlitz,
   .buttonStarted {
     width: 45%;

--- a/src/components/run-anywhere/run-anywhere.module.css
+++ b/src/components/run-anywhere/run-anywhere.module.css
@@ -5,8 +5,8 @@
 }
 
 .heading {
+  font-family: var(--font-primary-bold);
   font-size: var(--font-size-5);
-  font-weight: var(--font-weight-9);
   margin: 0;
   padding: var(--size-fluid-1) 0;
   text-align: center;

--- a/src/components/why-greenwood/why-greenwood.module.css
+++ b/src/components/why-greenwood/why-greenwood.module.css
@@ -7,8 +7,8 @@
 }
 
 .heading {
+  font-family: var(--font-primary-bold);
   font-size: var(--font-size-6);
-  font-weight: var(--font-weight-9);
   font-style: italic;
 }
 

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -18,6 +18,13 @@ app-hero-banner {
 @media (min-width: 1024px) {
   app-hero-banner,
   app-latest-post {
+    width: 80%;
+  }
+}
+
+@media (min-width: 1440px) {
+  app-hero-banner,
+  app-latest-post {
     width: 70%;
   }
 }


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

#30 

## Summary of Changes

> In #84 I realized why the bolded fonts weren't working, so this is intended to apply them once that PR lands

1. Apply bolded font to key home page sections
1. Cleaning up the font-weight in the heading / navigation helped fix #90 

## TODO
1. [x] Rebase against main once #84 is merged
1. [x] Remove all instances of `font-weight: bold` and replace with `font-family: var(--font-primary-bold)`
1. [x] Responsiveness checks