### PR TITLE
content/promote usage of init with project name flag

### DIFF
--- a/src/components/get-started/get-started.js
+++ b/src/components/get-started/get-started.js
@@ -2,7 +2,7 @@ import styles from "./get-started.module.css";
 
 export default class GetStarted extends HTMLElement {
   connectedCallback() {
-    const code = "npx @greenwood/init@latest";
+    const code = "npx @greenwood/init@latest my-app";
 
     this.innerHTML = `
       <div class="${styles.container}">

--- a/src/components/get-started/get-started.module.css
+++ b/src/components/get-started/get-started.module.css
@@ -22,7 +22,7 @@
 }
 
 .snippet pre {
-  font-size: 16px;
+  font-size: 10px;
   text-align: center;
   display: inline-block;
 }
@@ -75,7 +75,7 @@
 
 @media (min-width: 1024px) {
   .snippet {
-    max-width: 50%;
+    max-width: 60%;
   }
 
   .snippet pre {

--- a/src/components/hero-banner/hero-banner.js
+++ b/src/components/hero-banner/hero-banner.js
@@ -3,7 +3,7 @@ import emphasis from "../../assets/emphasis-corner.svg?type=raw";
 
 export default class HeroBanner extends HTMLElement {
   connectedCallback() {
-    const code = "npx @greenwood/init@latest";
+    const code = "npx @greenwood/init@latest my-app";
 
     this.innerHTML = `
       <div class="${styles.container}">

--- a/src/components/hero-banner/hero-banner.module.css
+++ b/src/components/hero-banner/hero-banner.module.css
@@ -81,7 +81,7 @@
 }
 
 .snippet pre {
-  font-size: var(--font-size-1);
+  font-size: 18px;
   display: inline-block;
   height: 46px;
   align-content: center;


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

https://github.com/ProjectEvergreen/greenwood/issues/1253

## Summary of Changes

1. Promote usage of `npx @greenwood/init` and specifying the project name flag