### PR TITLE
Issue-79: Recreate the json.svg to better align

### DIFF
--- a/src/assets/json.svg
+++ b/src/assets/json.svg
@@ -1,4 +1,8 @@
-<svg width="34" height="34" viewBox="0 0 34 34" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect x="0.5" y="0.5" width="33" height="33" rx="12.5" />
-<path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9.5 5H9a2 2 0 0 0-2 2v2c0 1-.6 3-3 3 1 0 3 .6 3 3v2a2 2 0 0 0 2 2h.5m5-14h.5a2 2 0 0 1 2 2v2c0 1 .6 3 3 3-1 0-3 .6-3 3v2a2 2 0 0 1-2 2h-.5"/>
+<svg width="34" height="34" viewBox="6 6 34 34" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect y="6.5" width="33" height="33" rx="12.5" x="6.811" style="stroke-width: 1.5px;"/>
+  <path
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    stroke-width="1.5"
+    d="M 20.708 14.585 L 19.988 14.585 C 18.397 14.585 17.107 15.789 17.107 17.275 L 17.107 19.964 C 17.107 21.31 16.242 23 12.784 23 C 14.225 23 17.107 22.806 17.107 26.034 L 17.107 28.724 C 17.107 30.21 18.397 31.414 19.988 31.414 L 20.708 31.414 M 25.913 14.585 L 26.633 14.585 C 28.226 14.585 29.515 15.789 29.515 17.275 L 29.515 19.964 C 29.515 21.31 30.379 23 33.837 23 C 32.397 23 29.515 22.806 29.515 26.034 L 29.515 28.724 C 29.515 30.21 28.226 31.414 26.633 31.414 L 25.913 31.414"/>
 </svg>

--- a/src/components/capabilities/capabilities.js
+++ b/src/components/capabilities/capabilities.js
@@ -4,6 +4,7 @@ import api from "../../assets/api-routes.svg?type=raw";
 import ssg from "../../assets/build-ssg.svg?type=raw";
 import html from "../../assets/html.svg?type=raw";
 import webComponents from "../../assets/web-components.svg?type=raw";
+import json from "../../assets/json.svg?type=raw";
 
 const template = document.createElement("template");
 
@@ -15,6 +16,7 @@ const availableIconSVGs = {
   "html.svg": html,
   "build-ssg.svg": ssg,
   "web-components.svg": webComponents,
+  "json.svg": json,
 };
 
 export default class Capabilities extends HTMLElement {

--- a/src/components/capabilities/capabilities.stories.js
+++ b/src/components/capabilities/capabilities.stories.js
@@ -49,7 +49,32 @@ const Template = () => `
 
     customElements.define("app-card", Card);
     </pre>
+  </div>
+  <div class="capabilities-content item3" style="display: none">
+    <span>API Routes</span>
+    <i>json.svg</i>
+    <span>API Routes</span>
 
+  <p>Need client side data fetching or mutations?  Greenwood provides API routes out of the box that are fully invested in web standards like <code>Fetch</code> and <code>FormData</code>.  Of course it is all fully compatible with server-rendering Web Components; a perfect companion for HTML over the wire solutions!</p>
+  <pre>// src/pages/api/search.js
+import { renderFromHTML } from "wc-compiler";
+import { getProducts } from "../lib/db.js";
+
+export async function handler(request) {
+  const formData = await request.formData();
+  const searchTerm = formData.has("term") ? formData.get("term") : "";
+  const products = await getProducts(searchTerm);
+  const { html } = await renderFromHTML(
+    JS HERE,
+    [new URL("../components/card.js", import.meta.url)],
+  );
+
+  return new Response(html, {
+    headers: new Headers({
+      "Content-Type": "text/html",
+    }),
+  });
+}</pre>
   </div>
 
   <app-capabilities></app-capabilities>

--- a/src/components/capabilities/capabilities.stories.js
+++ b/src/components/capabilities/capabilities.stories.js
@@ -50,31 +50,34 @@ const Template = () => `
     customElements.define("app-card", Card);
     </pre>
   </div>
+  
   <div class="capabilities-content item3" style="display: none">
     <span>API Routes</span>
     <i>json.svg</i>
     <span>API Routes</span>
 
-  <p>Need client side data fetching or mutations?  Greenwood provides API routes out of the box that are fully invested in web standards like <code>Fetch</code> and <code>FormData</code>.  Of course it is all fully compatible with server-rendering Web Components; a perfect companion for HTML over the wire solutions!</p>
-  <pre>// src/pages/api/search.js
-import { renderFromHTML } from "wc-compiler";
-import { getProducts } from "../lib/db.js";
+    <p>Need client side data fetching or mutations?  Greenwood provides API routes out of the box that are fully invested in web standards like <code>Fetch</code> and <code>FormData</code>.  Of course it is all fully compatible with server-rendering Web Components; a perfect companion for HTML over the wire solutions!</p>
+    
+    <pre>// src/pages/api/search.js
+    import { renderFromHTML } from "wc-compiler";
+    import { getProducts } from "../lib/db.js";
 
-export async function handler(request) {
-  const formData = await request.formData();
-  const searchTerm = formData.has("term") ? formData.get("term") : "";
-  const products = await getProducts(searchTerm);
-  const { html } = await renderFromHTML(
-    JS HERE,
-    [new URL("../components/card.js", import.meta.url)],
-  );
+    export async function handler(request) {
+      const formData = await request.formData();
+      const searchTerm = formData.has("term") ? formData.get("term") : "";
+      const products = await getProducts(searchTerm);
+      const { html } = await renderFromHTML(
+        JS HERE,
+        [new URL("../components/card.js", import.meta.url)],
+      );
 
-  return new Response(html, {
-    headers: new Headers({
-      "Content-Type": "text/html",
-    }),
-  });
-}</pre>
+      return new Response(html, {
+        headers: new Headers({
+          "Content-Type": "text/html",
+        }),
+      });
+    }
+    </pre>
   </div>
 
   <app-capabilities></app-capabilities>

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -118,7 +118,7 @@ imports:
 <!-- prettier-ignore-start -->
 <div class="capabilities-content item4">
   <span>API Routes</span>
-  <i>api-routes.svg</i>
+  <i>json.svg</i>
   <p>Need client side data fetching or mutations?  Greenwood provides API routes out of the box that are fully invested in web standards like <code>Fetch</code> and <code>FormData</code>.  Of course it is all fully compatible with server-rendering Web Components; a perfect companion for HTML over the wire solutions!</p>
 
   ```js


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

<!-- Include a link to the issue (e.g. Resolves #12).  If this is to document a Greenwood feature, please link that issue here. -->
Fix #79 

## Summary of Changes

- Recreated the json.svg to enlarge the curly braces and center them in the surrounding rectangle
- Update capabilities component to utilize the json.svg
- Include a new API Routes button within capabilities storybook

## Screenshots

**Home page**
<img width="548" alt="Screen Shot 2024-10-10 at 17 16 30" src="https://github.com/user-attachments/assets/539508c4-a8d2-4de7-a1c9-fd19dfa3b920">

**Storybook**
<img width="1298" alt="Screen Shot 2024-10-10 at 17 33 59" src="https://github.com/user-attachments/assets/2e03fd55-e2d1-45d7-8770-a23efdc6c612">


