### PR TITLE
enhancement/Issue-99: Refactor keyframes to be a transition

### DIFF
--- a/src/components/side-nav/side-nav.module.css
+++ b/src/components/side-nav/side-nav.module.css
@@ -34,24 +34,15 @@
 
   & #indicator {
     display: inline-block;
+    transition: transform 1s ease;
   }
 }
 
-.compactMenu:has(#compact-menu:popover-open) {
-  & #indicator {
-    animation: rotateindicatoropen 1s ease;
-    animation-fill-mode: forwards;
-  }
+.compactMenu:not(:has(#compact-menu:popover-open)) #indicator {
+  transform: rotate(0deg);
 }
-
-@keyframes rotateindicatoropen {
-  from {
-    transform: rotate(0deg);
-  }
-
-  to {
-    transform: rotate(180deg);
-  }
+.compactMenu:has(#compact-menu:popover-open) #indicator {
+  transform: rotate(180deg);
 }
 
 .compactMenuPopover {

--- a/src/components/table-of-contents/table-of-contents.module.css
+++ b/src/components/table-of-contents/table-of-contents.module.css
@@ -40,24 +40,15 @@
 
   & #indicator {
     display: inline-block;
+    transition: transform 1s ease;
   }
 }
 
-.compactMenu:has(#onthispage:popover-open) {
-  & #indicator {
-    animation: rotateindicatoropen 1s ease;
-    animation-fill-mode: forwards;
-  }
+.compactMenu:not(:has(#onthispage:popover-open)) #indicator {
+  transform: rotate(0deg);
 }
-
-@keyframes rotateindicatoropen {
-  from {
-    transform: rotate(0deg);
-  }
-
-  to {
-    transform: rotate(180deg);
-  }
+.compactMenu:has(#onthispage:popover-open) #indicator {
+  transform: rotate(180deg);
 }
 
 .compactMenuItem {


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

<!-- Include a link to the issue (e.g. Resolves #12).  If this is to document a Greenwood feature, please link that issue here. -->
Fix #99


## Summary of Changes

- Remove styles keyframes and replace with transition for popover indicators
    - Guides
    - Table of Contents

## Details

With keyframes it's a linear start-to-finish type animation. Our issue was that when the page/element loads, the animation starts. And in this case, would play the `backwards` animation which must first display the "finish" state and animate back to the "start".

With the `transition` property, we can set various states which are unaware of specific place in a linear timeline and the transition between them is seamless. So, we set the "has" state, and "not-has" state individually. When either of these states is changed, the browser will transition the property to the active state. 


https://github.com/user-attachments/assets/a0748faf-84eb-41fe-a5ee-ae9c65a3ec9d


