### PR TITLE
feature/Issue-97: Implement the Edit on GitHub component

### DIFF
--- a/src/components/edit-on-github/edit-on-github.js
+++ b/src/components/edit-on-github/edit-on-github.js
@@ -1,0 +1,36 @@
+import styles from './edit-on-github.module.css';
+
+const REPO_PREFIX = 'https://github.com/ProjectEvergreen/www.greenwoodjs.dev/tree/main/www/pages/';
+
+function convertRouteToSubLink(route) {
+  if (route === "/") return "index.md"; // root of diretory === index
+  
+  // trim leading slash
+  route = (route.charAt(0) === "/") 
+  ? route.substr(1)
+  : route;
+  
+  // append 'index.md' when necessary
+  return (route.substr(-3) !== '.md')
+    ? (route.charAt(route.length-1) === "/")
+      ? `${route}index.md`
+      : `${route}/index.md`
+    : route;
+}
+
+export default class EditOnGitHub extends HTMLElement {
+  connectedCallback() {
+    const route = this.getAttribute('route');
+    const subLink = convertRouteToSubLink(route);
+
+    this.innerHTML = `
+      <div class="${styles.container}">
+        <a title="Edit on GitHub" href="${REPO_PREFIX}${subLink}" target="_blank">
+          Edit on GitHub
+        </a>
+      </div>
+    `
+  }
+}
+
+customElements.define("app-edit-on-github", EditOnGitHub);

--- a/src/components/edit-on-github/edit-on-github.js
+++ b/src/components/edit-on-github/edit-on-github.js
@@ -1,6 +1,6 @@
 import styles from "./edit-on-github.module.css";
 
-const REPO_PREFIX = "https://github.com/ProjectEvergreen/www.greenwoodjs.dev/blob/main/src/pages/";
+const REPO_PREFIX = "https://github.com/ProjectEvergreen/www.greenwoodjs.dev/edit/main/src/pages/";
 
 function convertRouteToSubLink(route) {
   if (route === "/") return "index.md"; // root of diretory === index

--- a/src/components/edit-on-github/edit-on-github.js
+++ b/src/components/edit-on-github/edit-on-github.js
@@ -16,7 +16,6 @@ function convertRouteToSubLink(route) {
 
 export default class EditOnGitHub extends HTMLElement {
   connectedCallback() {
-    // protect against strigified "undefined"; occurs when the prop value is undefined in JS, but a string in HTML
     const label = "Edit on GitHub";
     const route = this.getAttribute("route");
     const href = `${REPO_PREFIX}${convertRouteToSubLink(route)}`;

--- a/src/components/edit-on-github/edit-on-github.js
+++ b/src/components/edit-on-github/edit-on-github.js
@@ -1,24 +1,24 @@
 import styles from "./edit-on-github.module.css";
 
-const REPO_PREFIX = "https://github.com/ProjectEvergreen/www.greenwoodjs.dev/edit/main/src/pages/";
+const REPO_PREFIX = "https://github.com/ProjectEvergreen/www.greenwoodjs.dev/edit/main/src/pages";
+const MAX_ROUTE_DEPTH = 5;
 
-function convertRouteToSubLink(route) {
-  if (route === "/") return "index.md"; // root of diretory === index
+// one / two segments - /guides/ -> /guides/index.md
+// three (max) segments - /guides/getting-started/key-concepts/ -> /guides/getting-started/key-concepts.md
+function convertRouteToEditLink(route) {
+  const segments = route.split("/");
 
-  const DIRS = ["guides", "ecosystem", "getting-started", "hosting", "tutorials"];
-
-  const routeParts = route.split("/").filter((param) => param !== "");
-  const trimmedRoute = routeParts.join("/");
-  const isDirectory = DIRS.includes(routeParts[routeParts.length - 1]);
-
-  return isDirectory ? `${trimmedRoute}/index.md` : `${trimmedRoute}.md`;
+  // https://stackoverflow.com/a/5497365/417806
+  return segments.length === MAX_ROUTE_DEPTH
+    ? `${route.replace(/\/([^/]*)$/, "")}.md`
+    : `${route}index.md`;
 }
 
 export default class EditOnGitHub extends HTMLElement {
   connectedCallback() {
     const label = "Edit on GitHub";
     const route = this.getAttribute("route");
-    const href = `${REPO_PREFIX}${convertRouteToSubLink(route)}`;
+    const href = `${REPO_PREFIX}${convertRouteToEditLink(route)}`;
 
     this.innerHTML = `
       <div class="${styles.container}">

--- a/src/components/edit-on-github/edit-on-github.js
+++ b/src/components/edit-on-github/edit-on-github.js
@@ -1,31 +1,23 @@
-import styles from './edit-on-github.module.css';
+import styles from "./edit-on-github.module.css";
 
-const REPO_PREFIX = 'https://github.com/ProjectEvergreen/www.greenwoodjs.dev/blob/main/src/pages/';
+const REPO_PREFIX = "https://github.com/ProjectEvergreen/www.greenwoodjs.dev/blob/main/src/pages/";
 
 function convertRouteToSubLink(route) {
   if (route === "/") return "index.md"; // root of diretory === index
 
-  const DIRS = [
-    'guides',
-    'ecosystem',
-    'getting-started',
-    'hosting',
-    'tutorials',
-  ];
-  
-  const routeParts = route.split('/').filter(param => param !== "");    
+  const DIRS = ["guides", "ecosystem", "getting-started", "hosting", "tutorials"];
+
+  const routeParts = route.split("/").filter((param) => param !== "");
   const trimmedRoute = routeParts.join("/");
-  const isDirectory = DIRS.includes(routeParts[routeParts.length-1]);
-  
-  return isDirectory
-      ? `${trimmedRoute}/index.md` 
-      : `${trimmedRoute}.md`;
+  const isDirectory = DIRS.includes(routeParts[routeParts.length - 1]);
+
+  return isDirectory ? `${trimmedRoute}/index.md` : `${trimmedRoute}.md`;
 }
 
 export default class EditOnGitHub extends HTMLElement {
   connectedCallback() {
-    const label = this.getAttribute('label') || 'Edit on GitHub';
-    const route = this.getAttribute('route');
+    const label = this.getAttribute("label") || "Edit on GitHub";
+    const route = this.getAttribute("route");
     const href = `${REPO_PREFIX}${convertRouteToSubLink(route)}`;
 
     this.innerHTML = `
@@ -34,7 +26,7 @@ export default class EditOnGitHub extends HTMLElement {
           ${label}
         </a>
       </div>
-    `
+    `;
   }
 }
 

--- a/src/components/edit-on-github/edit-on-github.js
+++ b/src/components/edit-on-github/edit-on-github.js
@@ -17,10 +17,7 @@ function convertRouteToSubLink(route) {
 export default class EditOnGitHub extends HTMLElement {
   connectedCallback() {
     // protect against strigified "undefined"; occurs when the prop value is undefined in JS, but a string in HTML
-    const label =
-      this.hasAttribute("label") && this.getAttribute("label") !== "undefined"
-        ? this.getAttribute("label")
-        : "Edit on GitHub";
+    const label = "Edit on GitHub";
     const route = this.getAttribute("route");
     const href = `${REPO_PREFIX}${convertRouteToSubLink(route)}`;
 

--- a/src/components/edit-on-github/edit-on-github.js
+++ b/src/components/edit-on-github/edit-on-github.js
@@ -16,7 +16,11 @@ function convertRouteToSubLink(route) {
 
 export default class EditOnGitHub extends HTMLElement {
   connectedCallback() {
-    const label = this.getAttribute("label") || "Edit on GitHub";
+    // protect against strigified "undefined"; occurs when the prop value is undefined in JS, but a string in HTML
+    const label =
+      this.hasAttribute("label") && this.getAttribute("label") !== "undefined"
+        ? this.getAttribute("label")
+        : "Edit on GitHub";
     const route = this.getAttribute("route");
     const href = `${REPO_PREFIX}${convertRouteToSubLink(route)}`;
 

--- a/src/components/edit-on-github/edit-on-github.js
+++ b/src/components/edit-on-github/edit-on-github.js
@@ -3,7 +3,6 @@ import styles from './edit-on-github.module.css';
 const REPO_PREFIX = 'https://github.com/ProjectEvergreen/www.greenwoodjs.dev/blob/main/src/pages/';
 
 function convertRouteToSubLink(route) {
-  console.log('incoming route', route);
   if (route === "/") return "index.md"; // root of diretory === index
 
   const DIRS = [
@@ -25,13 +24,14 @@ function convertRouteToSubLink(route) {
 
 export default class EditOnGitHub extends HTMLElement {
   connectedCallback() {
+    const label = this.getAttribute('label') || 'Edit on GitHub';
     const route = this.getAttribute('route');
-    const subLink = convertRouteToSubLink(route);
+    const href = `${REPO_PREFIX}${convertRouteToSubLink(route)}`;
 
     this.innerHTML = `
       <div class="${styles.container}">
-        <a title="Edit on GitHub" href="${REPO_PREFIX}${subLink}" target="_blank">
-          Edit on GitHub
+        <a title="${label}" href="${href}" target="_blank">
+          ${label}
         </a>
       </div>
     `

--- a/src/components/edit-on-github/edit-on-github.js
+++ b/src/components/edit-on-github/edit-on-github.js
@@ -1,21 +1,26 @@
 import styles from './edit-on-github.module.css';
 
-const REPO_PREFIX = 'https://github.com/ProjectEvergreen/www.greenwoodjs.dev/tree/main/www/pages/';
+const REPO_PREFIX = 'https://github.com/ProjectEvergreen/www.greenwoodjs.dev/blob/main/src/pages/';
 
 function convertRouteToSubLink(route) {
+  console.log('incoming route', route);
   if (route === "/") return "index.md"; // root of diretory === index
+
+  const DIRS = [
+    'guides',
+    'ecosystem',
+    'getting-started',
+    'hosting',
+    'tutorials',
+  ];
   
-  // trim leading slash
-  route = (route.charAt(0) === "/") 
-  ? route.substr(1)
-  : route;
+  const routeParts = route.split('/').filter(param => param !== "");    
+  const trimmedRoute = routeParts.join("/");
+  const isDirectory = DIRS.includes(routeParts[routeParts.length-1]);
   
-  // append 'index.md' when necessary
-  return (route.substr(-3) !== '.md')
-    ? (route.charAt(route.length-1) === "/")
-      ? `${route}index.md`
-      : `${route}/index.md`
-    : route;
+  return isDirectory
+      ? `${trimmedRoute}/index.md` 
+      : `${trimmedRoute}.md`;
 }
 
 export default class EditOnGitHub extends HTMLElement {

--- a/src/components/edit-on-github/edit-on-github.module.css
+++ b/src/components/edit-on-github/edit-on-github.module.css
@@ -10,12 +10,11 @@
   padding: calc(var(--size-1) + var(--size-2));
   border-radius: var(--size-px-2);
   background-color: var(--color-prism-bg);
-  text-decoration: none;
   color: var(--color-accent);
+  text-decoration: none;
+  box-shadow: 0 0 calc(var(--size-1) + var(--size-2)) var(--size-px-00) var(--color-white);
 }
 
 .container a:hover {
-  background-color: var(--color-prism-bg);
   text-decoration: underline;
-  color: var(--color-accent);
 }

--- a/src/components/edit-on-github/edit-on-github.module.css
+++ b/src/components/edit-on-github/edit-on-github.module.css
@@ -7,8 +7,8 @@
 .container a:active,
 .container a:focus,
 .container a:visited {
-  padding: 0.75em;
-  border-radius: 10px;
+  padding: calc(var(--size-1) + var(--size-2));
+  border-radius: var(--size-px-2);
   background-color: var(--color-prism-bg);
   text-decoration: none;
   color: var(--color-accent);

--- a/src/components/edit-on-github/edit-on-github.module.css
+++ b/src/components/edit-on-github/edit-on-github.module.css
@@ -1,0 +1,21 @@
+.container {
+  margin: 0;
+  padding: 0;
+}
+
+.container a,
+.container a:active,
+.container a:focus,
+.container a:visited {
+  padding: 0.75em;
+  border-radius: 10px;
+  background-color: var(--color-prism-bg);
+  text-decoration: none;
+  color: var(--color-accent);
+}
+
+.container a:hover {
+  background-color: var(--color-prism-bg);
+  text-decoration: underline;
+  color: var(--color-accent);
+}

--- a/src/components/edit-on-github/edit-on-github.spec.js
+++ b/src/components/edit-on-github/edit-on-github.spec.js
@@ -44,12 +44,12 @@ describe("Components/Edit on GitHub", () => {
     });
 
     it("should render the text 'Edit on GitHub'", () => {
-      // use trim due to allow backtick use
+      // use trim to allow backtick use in code
       expect(editLink.text.trim()).equal("Edit on GitHub");
     });
 
-    describe("when the route is ONLY a leading slash", () => {
-      it("should return root-level ('/') as 'index.md'", () => {
+    describe("when the route is ONLY a slash", () => {
+      it("should return 'index.md' for root-level ('/')", () => {
         const expected = `${EXPECTED_BASE}index.md`;
 
         expect(editLink.getAttribute("href")).equal(expected);
@@ -72,7 +72,7 @@ describe("Components/Edit on GitHub", () => {
         editLink = editWrapper.querySelector("a")
       });
 
-      it("should include a href attribute which includes the index.md filepath", () => {
+      it("should include a href attribute which includes filepath.md", () => {
         const expected = `${EXPECTED_BASE}some/static/filename.md`;
 
         expect(editLink.getAttribute("href")).equal(expected);
@@ -95,7 +95,7 @@ describe("Components/Edit on GitHub", () => {
         editLink = editWrapper.querySelector("a")
       });
 
-      it("should include a href attribute which includes the provided route", () => {
+      it("should include a href attribute which includes index.md", () => {
         const expected = `${EXPECTED_BASE}some/path/to/hosting/index.md`
 
         expect(editLink.getAttribute("href")).equal(expected);

--- a/src/components/edit-on-github/edit-on-github.spec.js
+++ b/src/components/edit-on-github/edit-on-github.spec.js
@@ -33,7 +33,7 @@ describe("Components/Edit on GitHub", () => {
 
   describe("Anchor tag to GitHub", () => {
     const EXPECTED_BASE =
-      "https://github.com/ProjectEvergreen/www.greenwoodjs.dev/blob/main/src/pages/"; // including trailing
+      "https://github.com/ProjectEvergreen/www.greenwoodjs.dev/edit/main/src/pages/"; // including trailing
 
     it("should render an anchor tag targeting a new window", () => {
       expect(editLink).not.equal(undefined);

--- a/src/components/edit-on-github/edit-on-github.spec.js
+++ b/src/components/edit-on-github/edit-on-github.spec.js
@@ -1,13 +1,5 @@
 import { expect } from "@esm-bundle/chai";
 import "./edit-on-github.js";
-import graph from "../../stories/mocks/graph.json" with { type: "json" };
-
-// https://stackoverflow.com/questions/45425169/intercept-fetch-api-requests-and-responses-in-javascript
-window.fetch = function () {
-  return new Promise((resolve) => {
-    resolve(new Response(JSON.stringify(graph)));
-  });
-};
 
 // attributes
 const ROUTE = "/";

--- a/src/components/edit-on-github/edit-on-github.spec.js
+++ b/src/components/edit-on-github/edit-on-github.spec.js
@@ -32,6 +32,8 @@ describe("Components/Edit on GitHub", () => {
   });
 
   describe("Anchor tag to GitHub", () => {
+    const EXPECTED_BASE = "https://github.com/ProjectEvergreen/www.greenwoodjs.dev/blob/main/src/pages/"; // including trailing
+
     it("should render an anchor tag targeting a new window", () => {
       expect(editLink).not.equal(undefined);
       expect(editLink.getAttribute("target")).equal("_blank");
@@ -47,21 +49,21 @@ describe("Components/Edit on GitHub", () => {
     });
 
     describe("when the route is ONLY a leading slash", () => {
-      it("should default to 'index.md'", () => {
-        const expected = "https://github.com/ProjectEvergreen/www.greenwoodjs.dev/tree/main/www/pages/index.md"
+      it("should return root-level ('/') as 'index.md'", () => {
+        const expected = `${EXPECTED_BASE}index.md`;
 
         expect(editLink.getAttribute("href")).equal(expected);
       });
     });
 
-    describe("when the route DOES NOT contain a markdown file", () => {
-      let missingFilenamePath;
+    describe("when the route IS NOT a directory", () => {
+      let staticFilepath;
 
       before(async () => {
-        missingFilenamePath = 'some/path/without/'; // ie: "guides/getting-started/"
+        staticFilepath = '/some/static/filename/'; // ie: "/guides/hosting/netlify/"
 
         editWrapper = document.createElement("app-edit-on-github");
-        editWrapper.setAttribute("route", missingFilenamePath);
+        editWrapper.setAttribute("route", staticFilepath);
     
         document.body.appendChild(editWrapper);
         
@@ -71,17 +73,17 @@ describe("Components/Edit on GitHub", () => {
       });
 
       it("should include a href attribute which includes the index.md filepath", () => {
-        const expected = "https://github.com/ProjectEvergreen/www.greenwoodjs.dev/tree/main/www/pages/some/path/without/index.md"
+        const expected = `${EXPECTED_BASE}some/static/filename.md`;
 
         expect(editLink.getAttribute("href")).equal(expected);
       });
     })
 
-    describe("when the route DOES NOT have a leading slash", () => {
+    describe("when the route IS a directory", () => {
       let missingTrailingPath;
 
       before(async () => {
-        missingTrailingPath = 'some/path/without/leading.md'; // ie: "guides/getting-started/going-further.md"
+        missingTrailingPath = '/some/path/to/hosting/'; // ie: "/guides/hosting/"
 
         editWrapper = document.createElement("app-edit-on-github");
         editWrapper.setAttribute("route", missingTrailingPath);
@@ -94,30 +96,7 @@ describe("Components/Edit on GitHub", () => {
       });
 
       it("should include a href attribute which includes the provided route", () => {
-        const expected = "https://github.com/ProjectEvergreen/www.greenwoodjs.dev/tree/main/www/pages/some/path/without/leading.md"
-
-        expect(editLink.getAttribute("href")).equal(expected);
-      });
-    });
-
-    describe("when the route DOES have a trailing slash", () => {
-      let includingTrailingPath;
-
-      before(async () => {
-        includingTrailingPath = '/some/path/without/leading.md'; // ie: "/guides/getting-started/going-further.md"
-
-        editWrapper = document.createElement("app-edit-on-github");
-        editWrapper.setAttribute("route", includingTrailingPath);
-    
-        document.body.appendChild(editWrapper);
-        
-        await editWrapper.updateComplete;
-    
-        editLink = editWrapper.querySelector("a")
-      });
-
-      it("should include a title attribute with the label 'Edit on GitHub'", () => {
-        const expected = "https://github.com/ProjectEvergreen/www.greenwoodjs.dev/tree/main/www/pages/some/path/without/leading.md"
+        const expected = `${EXPECTED_BASE}some/path/to/hosting/index.md`
 
         expect(editLink.getAttribute("href")).equal(expected);
       });

--- a/src/components/edit-on-github/edit-on-github.spec.js
+++ b/src/components/edit-on-github/edit-on-github.spec.js
@@ -1,0 +1,126 @@
+import { expect } from "@esm-bundle/chai";
+import "./edit-on-github.js";
+import graph from "../../stories/mocks/graph.json" with { type: "json" };
+
+// https://stackoverflow.com/questions/45425169/intercept-fetch-api-requests-and-responses-in-javascript
+window.fetch = function () {
+  return new Promise((resolve) => {
+    resolve(new Response(JSON.stringify(graph)));
+  });
+};
+
+// attributes
+const ROUTE = "/" 
+
+describe("Components/Edit on GitHub", () => {
+  let editWrapper;
+  let editLink;
+
+  before(async () => {
+    editWrapper = document.createElement("app-edit-on-github");
+    editWrapper.setAttribute("route", ROUTE);
+
+    document.body.appendChild(editWrapper);
+    
+    await editWrapper.updateComplete;
+
+    editLink = editWrapper.querySelector("a")
+  });
+
+  it("should not be undefined", () => {
+    expect(editWrapper).not.equal(undefined);
+  });
+
+  describe("Anchor tag to GitHub", () => {
+    it("should render an anchor tag targeting a new window", () => {
+      expect(editLink).not.equal(undefined);
+      expect(editLink.getAttribute("target")).equal("_blank");
+    });
+
+    it("should include a title attribute with the label 'Edit on GitHub'", () => {
+      expect(editLink.getAttribute("title")).equal("Edit on GitHub");
+    });
+
+    it("should render the text 'Edit on GitHub'", () => {
+      // use trim due to allow backtick use
+      expect(editLink.text.trim()).equal("Edit on GitHub");
+    });
+
+    describe("when the route is ONLY a leading slash", () => {
+      it("should default to 'index.md'", () => {
+        const expected = "https://github.com/ProjectEvergreen/www.greenwoodjs.dev/tree/main/www/pages/index.md"
+
+        expect(editLink.getAttribute("href")).equal(expected);
+      });
+    });
+
+    describe("when the route DOES NOT contain a markdown file", () => {
+      let missingFilenamePath;
+
+      before(async () => {
+        missingFilenamePath = 'some/path/without/'; // ie: "guides/getting-started/"
+
+        editWrapper = document.createElement("app-edit-on-github");
+        editWrapper.setAttribute("route", missingFilenamePath);
+    
+        document.body.appendChild(editWrapper);
+        
+        await editWrapper.updateComplete;
+    
+        editLink = editWrapper.querySelector("a")
+      });
+
+      it("should include a href attribute which includes the index.md filepath", () => {
+        const expected = "https://github.com/ProjectEvergreen/www.greenwoodjs.dev/tree/main/www/pages/some/path/without/index.md"
+
+        expect(editLink.getAttribute("href")).equal(expected);
+      });
+    })
+
+    describe("when the route DOES NOT have a leading slash", () => {
+      let missingTrailingPath;
+
+      before(async () => {
+        missingTrailingPath = 'some/path/without/leading.md'; // ie: "guides/getting-started/going-further.md"
+
+        editWrapper = document.createElement("app-edit-on-github");
+        editWrapper.setAttribute("route", missingTrailingPath);
+    
+        document.body.appendChild(editWrapper);
+        
+        await editWrapper.updateComplete;
+    
+        editLink = editWrapper.querySelector("a")
+      });
+
+      it("should include a href attribute which includes the provided route", () => {
+        const expected = "https://github.com/ProjectEvergreen/www.greenwoodjs.dev/tree/main/www/pages/some/path/without/leading.md"
+
+        expect(editLink.getAttribute("href")).equal(expected);
+      });
+    });
+
+    describe("when the route DOES have a trailing slash", () => {
+      let includingTrailingPath;
+
+      before(async () => {
+        includingTrailingPath = '/some/path/without/leading.md'; // ie: "/guides/getting-started/going-further.md"
+
+        editWrapper = document.createElement("app-edit-on-github");
+        editWrapper.setAttribute("route", includingTrailingPath);
+    
+        document.body.appendChild(editWrapper);
+        
+        await editWrapper.updateComplete;
+    
+        editLink = editWrapper.querySelector("a")
+      });
+
+      it("should include a title attribute with the label 'Edit on GitHub'", () => {
+        const expected = "https://github.com/ProjectEvergreen/www.greenwoodjs.dev/tree/main/www/pages/some/path/without/leading.md"
+
+        expect(editLink.getAttribute("href")).equal(expected);
+      });
+    });
+  });
+});

--- a/src/components/edit-on-github/edit-on-github.spec.js
+++ b/src/components/edit-on-github/edit-on-github.spec.js
@@ -10,7 +10,7 @@ window.fetch = function () {
 };
 
 // attributes
-const ROUTE = "/" 
+const ROUTE = "/";
 
 describe("Components/Edit on GitHub", () => {
   let editWrapper;
@@ -21,10 +21,10 @@ describe("Components/Edit on GitHub", () => {
     editWrapper.setAttribute("route", ROUTE);
 
     document.body.appendChild(editWrapper);
-    
+
     await editWrapper.updateComplete;
 
-    editLink = editWrapper.querySelector("a")
+    editLink = editWrapper.querySelector("a");
   });
 
   it("should not be undefined", () => {
@@ -32,7 +32,8 @@ describe("Components/Edit on GitHub", () => {
   });
 
   describe("Anchor tag to GitHub", () => {
-    const EXPECTED_BASE = "https://github.com/ProjectEvergreen/www.greenwoodjs.dev/blob/main/src/pages/"; // including trailing
+    const EXPECTED_BASE =
+      "https://github.com/ProjectEvergreen/www.greenwoodjs.dev/blob/main/src/pages/"; // including trailing
 
     it("should render an anchor tag targeting a new window", () => {
       expect(editLink).not.equal(undefined);
@@ -60,16 +61,16 @@ describe("Components/Edit on GitHub", () => {
       let staticFilepath;
 
       before(async () => {
-        staticFilepath = '/some/static/filename/'; // ie: "/guides/hosting/netlify/"
+        staticFilepath = "/some/static/filename/"; // ie: "/guides/hosting/netlify/"
 
         editWrapper = document.createElement("app-edit-on-github");
         editWrapper.setAttribute("route", staticFilepath);
-    
+
         document.body.appendChild(editWrapper);
-        
+
         await editWrapper.updateComplete;
-    
-        editLink = editWrapper.querySelector("a")
+
+        editLink = editWrapper.querySelector("a");
       });
 
       it("should include a href attribute which includes filepath.md", () => {
@@ -77,26 +78,26 @@ describe("Components/Edit on GitHub", () => {
 
         expect(editLink.getAttribute("href")).equal(expected);
       });
-    })
+    });
 
     describe("when the route IS a directory", () => {
       let missingTrailingPath;
 
       before(async () => {
-        missingTrailingPath = '/some/path/to/hosting/'; // ie: "/guides/hosting/"
+        missingTrailingPath = "/some/path/to/hosting/"; // ie: "/guides/hosting/"
 
         editWrapper = document.createElement("app-edit-on-github");
         editWrapper.setAttribute("route", missingTrailingPath);
-    
+
         document.body.appendChild(editWrapper);
-        
+
         await editWrapper.updateComplete;
-    
-        editLink = editWrapper.querySelector("a")
+
+        editLink = editWrapper.querySelector("a");
       });
 
       it("should include a href attribute which includes index.md", () => {
-        const expected = `${EXPECTED_BASE}some/path/to/hosting/index.md`
+        const expected = `${EXPECTED_BASE}some/path/to/hosting/index.md`;
 
         expect(editLink.getAttribute("href")).equal(expected);
       });

--- a/src/components/edit-on-github/edit-on-github.stories.js
+++ b/src/components/edit-on-github/edit-on-github.stories.js
@@ -23,7 +23,7 @@ export default {
 const Template = (props) => {
   return `
     <div style="margin:1em 0;"><p>Linked File: ${props.args.route}</p></div>
-    <app-edit-on-github label="${props.args.label}" route="${props.args.route}"></app-edit-on-github>
+    <app-edit-on-github route="${props.args.route}"></app-edit-on-github>
   `;
 };
 

--- a/src/components/edit-on-github/edit-on-github.stories.js
+++ b/src/components/edit-on-github/edit-on-github.stories.js
@@ -3,6 +3,7 @@ import pages from "../../stories/mocks/graph.json";
 
 export default {
   title: "Components/Edit on GitHub",
+  component: "app-edit-on-github",
   parameters: {
     fetchMock: {
       mocks: [
@@ -19,6 +20,48 @@ export default {
   },
 };
 
-const Template = () => "<app-edit-on-github route='/guides/getting-started/'></app-edit-on-github>";
+const Template = (props) => {
+  return `
+    <div style="margin:1em 0;"><p>Linked File: ${props.args.route}</p></div>
+    <app-edit-on-github label="${props.args.label}" route="${props.args.route}"></app-edit-on-github>
+  `;
+};
 
-export const Primary = Template.bind({});
+export const DefaultLabel = Template.bind(
+  {},
+  {
+    args: {
+      route: "/",
+    },
+  },
+);
+
+export const Root = Template.bind(
+  {},
+  {
+    args: {
+      route: "/",
+      label: "Edit Root Page",
+    },
+  },
+);
+
+export const Directory = Template.bind(
+  {},
+  {
+    args: {
+      route: "/guides/hosting/",
+      label: "Edit Directory Page",
+    },
+  },
+);
+
+export const Static = Template.bind(
+  {},
+  {
+    args: {
+      route: "/guides/hosting/netlify",
+      label: "Edit Static Page",
+    },
+  },
+);

--- a/src/components/edit-on-github/edit-on-github.stories.js
+++ b/src/components/edit-on-github/edit-on-github.stories.js
@@ -1,0 +1,24 @@
+import "./edit-on-github.js";
+import pages from "../../stories/mocks/graph.json";
+
+export default {
+  title: "Components/Edit on GitHub",
+  parameters: {
+    fetchMock: {
+      mocks: [
+        {
+          matcher: {
+            url: "http://localhost:1985/graph.json",
+            response: {
+              body: pages,
+            },
+          },
+        },
+      ],
+    },
+  },
+};
+
+const Template = () => "<app-edit-on-github route='/guides/getting-started/'></app-edit-on-github>";
+
+export const Primary = Template.bind({});

--- a/src/components/edit-on-github/edit-on-github.stories.js
+++ b/src/components/edit-on-github/edit-on-github.stories.js
@@ -12,16 +12,16 @@ const Template = (props) => {
   `;
 };
 
-export const Root = Template.bind(
+export const PageRoot = Template.bind(
   {},
   {
     args: {
-      route: "/",
+      route: "/guides/",
     },
   },
 );
 
-export const Directory = Template.bind(
+export const SectionRoot = Template.bind(
   {},
   {
     args: {
@@ -30,11 +30,11 @@ export const Directory = Template.bind(
   },
 );
 
-export const Static = Template.bind(
+export const Section = Template.bind(
   {},
   {
     args: {
-      route: "/guides/hosting/netlify",
+      route: "/guides/hosting/netlify/",
     },
   },
 );

--- a/src/components/edit-on-github/edit-on-github.stories.js
+++ b/src/components/edit-on-github/edit-on-github.stories.js
@@ -1,40 +1,16 @@
 import "./edit-on-github.js";
-import pages from "../../stories/mocks/graph.json";
 
 export default {
   title: "Components/Edit on GitHub",
   component: "app-edit-on-github",
-  parameters: {
-    fetchMock: {
-      mocks: [
-        {
-          matcher: {
-            url: "http://localhost:1985/graph.json",
-            response: {
-              body: pages,
-            },
-          },
-        },
-      ],
-    },
-  },
 };
 
 const Template = (props) => {
   return `
-    <div style="margin:1em 0;"><p>Linked File: ${props.args.route}</p></div>
+    <div style="margin:1em 0;"><p>Linked Route: ${props.args.route}</p></div>
     <app-edit-on-github route="${props.args.route}"></app-edit-on-github>
   `;
 };
-
-export const DefaultLabel = Template.bind(
-  {},
-  {
-    args: {
-      route: "/",
-    },
-  },
-);
 
 export const Root = Template.bind(
   {},

--- a/src/components/edit-on-github/edit-on-github.stories.js
+++ b/src/components/edit-on-github/edit-on-github.stories.js
@@ -41,7 +41,6 @@ export const Root = Template.bind(
   {
     args: {
       route: "/",
-      label: "Edit Root Page",
     },
   },
 );
@@ -51,7 +50,6 @@ export const Directory = Template.bind(
   {
     args: {
       route: "/guides/hosting/",
-      label: "Edit Directory Page",
     },
   },
 );
@@ -61,7 +59,6 @@ export const Static = Template.bind(
   {
     args: {
       route: "/guides/hosting/netlify",
-      label: "Edit Static Page",
     },
   },
 );

--- a/src/components/footer/footer.js
+++ b/src/components/footer/footer.js
@@ -7,7 +7,7 @@ import greenwoodLogo from "../../assets/greenwood-logo-full.svg?type=raw";
 export default class Footer extends HTMLElement {
   connectedCallback() {
     this.innerHTML = `
-      <footer class="${styles.footer}" id="app-footer">
+      <footer class="${styles.footer}">
         <div class="${styles.logo}">
           ${greenwoodLogo}
         </div>

--- a/src/components/footer/footer.js
+++ b/src/components/footer/footer.js
@@ -7,7 +7,7 @@ import greenwoodLogo from "../../assets/greenwood-logo-full.svg?type=raw";
 export default class Footer extends HTMLElement {
   connectedCallback() {
     this.innerHTML = `
-      <footer class="${styles.footer}">
+      <footer class="${styles.footer}" id="app-footer">
         <div class="${styles.logo}">
           ${greenwoodLogo}
         </div>

--- a/src/layouts/guides.html
+++ b/src/layouts/guides.html
@@ -76,6 +76,13 @@
         }
       }
 
+      .content-footer {
+        padding: 1em 0;
+        position: sticky;
+        bottom: 0;
+        margin-top: 26px;
+      }
+
       app-heading-box {
         & .spacer {
           display: block;
@@ -166,7 +173,22 @@
 
     <div class="content-outlet">
       <content-outlet></content-outlet>
-      <app-edit-on-github route="${globalThis.page.route}"></app-edit-on-github>
+      <div class="content-footer">
+        <script>
+          // TODO - convert to a component?
+          if (
+            "IntersectionObserver" in window &&
+            "IntersectionObserverEntry" in window &&
+            "intersectionRatio" in window.IntersectionObserverEntry.prototype
+          ) {
+          let observer = new IntersectionObserver(entries => {
+            console.log('observe', entries);
+          });
+          observer.observe(document.querySelector(".content-outlet"));
+          }
+        </script>
+        <app-edit-on-github route="${globalThis.page.route}"></app-edit-on-github>
+      </div>
     </div>
   </body>
 </html>

--- a/src/layouts/guides.html
+++ b/src/layouts/guides.html
@@ -12,6 +12,11 @@
       src="../components/table-of-contents/table-of-contents.js"
       data-gwd-opt="static"
     ></script>
+    <script
+      type="module"
+      src="../components/edit-on-github/edit-on-github.js"
+      data-gwd-opt="static"
+    ></script>
     <style>
       body:has(#compact-menu:popover-open) {
         overflow-y: hidden;
@@ -161,6 +166,7 @@
 
     <div class="content-outlet">
       <content-outlet></content-outlet>
+      <app-edit-on-github route="${globalThis.page.route}"></app-edit-on-github>
     </div>
   </body>
 </html>

--- a/src/layouts/guides.html
+++ b/src/layouts/guides.html
@@ -76,16 +76,13 @@
         }
       }
 
-      .content-outlet > div {
+      app-edit-on-github {
+        display: block;
         padding: var(--size-3) 0;
         position: sticky;
         bottom: 0;
         text-align: right;
-        margin: var(--size-px-6) 0 var(--size-px-2) 0;
-      }
-
-      .content-outlet div[class*="edit-on-github"] a {
-        box-shadow: 0 0 calc(var(--size-1) + var(--size-2)) var(--size-px-00) var(--color-white);
+        margin: var(--size-px-7) 0 var(--size-px-3) 0;
       }
 
       app-heading-box {
@@ -125,7 +122,7 @@
           font-size: var(--font-size-1);
         }
 
-        .content-outlet > div {
+        app-edit-on-github {
           position: fixed;
           bottom: var(--size-10);
           right: var(--size-6);
@@ -184,9 +181,7 @@
 
     <div class="content-outlet">
       <content-outlet></content-outlet>
-      <div>
-        <app-edit-on-github route="${globalThis.page.route}"></app-edit-on-github>
-      </div>
+      <app-edit-on-github route="${globalThis.page.route}"></app-edit-on-github>
     </div>
   </body>
 </html>

--- a/src/layouts/guides.html
+++ b/src/layouts/guides.html
@@ -83,8 +83,8 @@
         margin-top: 26px;
       }
 
-      .content-footer a[title="Edit on GitHub"] {
-        box-shadow: 0px 0px 20px -3px #fff;
+      .content-footer a {
+        box-shadow: 0px 0px 12px -3px var(--color-white);
       }
 
       app-heading-box {

--- a/src/layouts/guides.html
+++ b/src/layouts/guides.html
@@ -76,15 +76,16 @@
         }
       }
 
-      .content-footer {
-        padding: 1em 0;
+      .content-outlet > div {
+        padding: var(--size-3) 0;
         position: sticky;
         bottom: 0;
-        margin-top: 26px;
+        text-align: right;
+        margin: var(--size-px-6) 0 var(--size-px-2) 0;
       }
 
-      .content-footer a {
-        box-shadow: 0px 0px 12px -3px var(--color-white);
+      .content-outlet div[class*="edit-on-github"] a {
+        box-shadow: 0 0 calc(var(--size-1) + var(--size-2)) var(--size-px-00) var(--color-white);
       }
 
       app-heading-box {
@@ -124,7 +125,7 @@
           font-size: var(--font-size-1);
         }
 
-        .content-footer {
+        .content-outlet > div {
           position: fixed;
           bottom: var(--size-10);
           right: var(--size-6);
@@ -183,7 +184,7 @@
 
     <div class="content-outlet">
       <content-outlet></content-outlet>
-      <div class="content-footer">
+      <div>
         <app-edit-on-github route="${globalThis.page.route}"></app-edit-on-github>
       </div>
     </div>

--- a/src/layouts/guides.html
+++ b/src/layouts/guides.html
@@ -83,6 +83,10 @@
         margin-top: 26px;
       }
 
+      .content-footer a[title="Edit on GitHub"] {
+        box-shadow: 0px 0px 20px -3px #fff;
+      }
+
       app-heading-box {
         & .spacer {
           display: block;
@@ -118,6 +122,12 @@
           display: inline-block;
           width: 45%;
           font-size: var(--font-size-1);
+        }
+
+        .content-footer {
+          position: fixed;
+          bottom: var(--size-10);
+          right: var(--size-6);
         }
 
         app-side-nav {
@@ -174,19 +184,6 @@
     <div class="content-outlet">
       <content-outlet></content-outlet>
       <div class="content-footer">
-        <script>
-          // TODO - convert to a component?
-          if (
-            "IntersectionObserver" in window &&
-            "IntersectionObserverEntry" in window &&
-            "intersectionRatio" in window.IntersectionObserverEntry.prototype
-          ) {
-          let observer = new IntersectionObserver(entries => {
-            console.log('observe', entries);
-          });
-          observer.observe(document.querySelector(".content-outlet"));
-          }
-        </script>
         <app-edit-on-github route="${globalThis.page.route}"></app-edit-on-github>
       </div>
     </div>

--- a/src/stories/mocks/graph.json
+++ b/src/stories/mocks/graph.json
@@ -1213,6 +1213,7 @@
       "../components/run-anywhere/run-anywhere.js data-gwd-opt=\"static\" type=\"module\"",
       "../components/build-with-friends/build-with-friends.js data-gwd-opt=\"static\" type=\"module\"",
       "../components/get-started/get-started.js data-gwd-opt=\"static\" type=\"module\"",
+      "../components/edit-on-github/edit-on-github.js data-gwd-opt=\"static\" type=\"module\"",
       "../styles/home.css"
     ],
     "resources": [],


### PR DESCRIPTION
## Related Issue
Fix #97 

## Summary of Changes

- Create `<app-edit-on-github>` component
- Create test suite for potential inputs
- Create styles to make button sticky and responsive
- Create initial story example

## Screenshots
- **<= 1199px**
<img width="350" alt="Screen Shot 2024-10-14 at 00 55 02" src="https://github.com/user-attachments/assets/d9113cd9-ccbd-44aa-bc12-dc80cc1447bd">
- ** >=1200px**
<img width="350" alt="Screen Shot 2024-10-14 at 00 55 29" src="https://github.com/user-attachments/assets/5536c7bc-8b7f-431d-8df8-039f30bf165e">


https://github.com/user-attachments/assets/7d3bab17-9175-40c5-894d-c6d1c3f0da03

https://github.com/user-attachments/assets/637f28af-5110-4f2b-b494-eb81da2ac331



## Todo

- [x] Additional story examples
