### PR TITLE
chore/Issue-51: Refactor lint-staged config

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,5 +1,5 @@
 export default {
-  "*.js": ["npm run lint:js --", "npm run format --"],
+  "*.js": ["npm run lint:js --"],
   "*.css": "npm run lint:css --",
   "*.*": ["npm run lint:ls --", "npm run format --"],
 };

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,0 +1,5 @@
+export default {
+  "*.js": ["npm run lint:js --", "npm run format --"],
+  "*.css": "npm run lint:css --",
+  "*.*": ["npm run lint:ls --", "npm run format --"],
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "storybook": "^8.0.6",
         "storybook-addon-fetch-mock": "^2.0.1",
         "stylelint": "^16.4.0",
-        "stylelint-prettier": "^5.0.0",
+        "stylelint-config-recommended": "^14.0.1",
         "vite": "^5.2.8"
       },
       "engines": {
@@ -8363,11 +8363,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-diff": {
-      "version": "1.3.0",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
       "dev": true,
@@ -14190,17 +14185,6 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
-    "node_modules/prettier-linter-helpers": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-diff": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/pretty-format": {
       "version": "27.5.1",
       "dev": true,
@@ -16011,19 +15995,26 @@
         "url": "https://opencollective.com/stylelint"
       }
     },
-    "node_modules/stylelint-prettier": {
-      "version": "5.0.0",
+    "node_modules/stylelint-config-recommended": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-14.0.1.tgz",
+      "integrity": "sha512-bLvc1WOz/14aPImu/cufKAZYfXs/A/owZfSMZ4N+16WGXLoX5lOir53M6odBxvhgmgdxCVnNySJmZKx73T93cg==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "prettier-linter-helpers": "^1.0.0"
-      },
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/stylelint"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/stylelint"
+        }
+      ],
       "engines": {
         "node": ">=18.12.0"
       },
       "peerDependencies": {
-        "prettier": ">=3.0.0",
-        "stylelint": ">=16.0.0"
+        "stylelint": "^16.1.0"
       }
     },
     "node_modules/stylelint/node_modules/ansi-regex": {

--- a/package.json
+++ b/package.json
@@ -81,8 +81,11 @@
     "@rollup/rollup-linux-x64-gnu": "^4.17.2"
   },
   "lint-staged": {
-    "*.js": "npm run lint:js",
-    "*.css": "npm run lint:css",
-    "**/*": "npm run lint:ls && npm run format"
+    "*.js": [
+      "eslint -c ./eslint.config.js",
+      "prettier . --write"
+    ],
+    "*.css": "stylelint \"./src/**/*.css\"",
+    "*.*": "ls-lint"
   }
 }

--- a/package.json
+++ b/package.json
@@ -74,18 +74,10 @@
     "storybook": "^8.0.6",
     "storybook-addon-fetch-mock": "^2.0.1",
     "stylelint": "^16.4.0",
-    "stylelint-prettier": "^5.0.0",
+    "stylelint-config-recommended": "^14.0.1",
     "vite": "^5.2.8"
   },
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "^4.17.2"
-  },
-  "lint-staged": {
-    "*.js": [
-      "npm run lint:js --",
-      "npm run format --"
-    ],
-    "*.css": "npm run lint:css --",
-    "*.*": "npm run lint:ls --"
   }
 }

--- a/package.json
+++ b/package.json
@@ -82,10 +82,10 @@
   },
   "lint-staged": {
     "*.js": [
-      "eslint -c ./eslint.config.js",
-      "prettier . --write"
+      "npm run lint:js --",
+      "npm run format --"
     ],
-    "*.css": "stylelint \"./src/**/*.css\"",
-    "*.*": "ls-lint"
+    "*.css": "npm run lint:css --",
+    "*.*": "npm run lint:ls --"
   }
 }

--- a/src/components/capabilities/capabilities.css
+++ b/src/components/capabilities/capabilities.css
@@ -9,22 +9,9 @@
   font-size: var(--font-size-1);
 }
 
-/* consolidated below */
-/* .heading {
-  font-family: var(--font-primary-bold);
-  font-size: var(--font-size-6);
-} */
-
 .container {
   padding: var(--size-fluid-2);
 }
-
-/* consolidated below */
-/* .sections {
-  overflow-x: auto;
-  scrollbar-width: thin;
-  scrollbar-color: var(--color-gray) transparent;
-} */
 
 .section {
   display: inline-block;

--- a/src/components/capabilities/capabilities.css
+++ b/src/components/capabilities/capabilities.css
@@ -9,20 +9,22 @@
   font-size: var(--font-size-1);
 }
 
-.heading {
+/* consolidated below */
+/* .heading {
   font-family: var(--font-primary-bold);
   font-size: var(--font-size-6);
-}
+} */
 
 .container {
   padding: var(--size-fluid-2);
 }
 
-.sections {
+/* consolidated below */
+/* .sections {
   overflow-x: auto;
   scrollbar-width: thin;
   scrollbar-color: var(--color-gray) transparent;
-}
+} */
 
 .section {
   display: inline-block;
@@ -91,6 +93,8 @@
   border-top: 1px solid var(--color-accent);
   border-bottom: 1px solid var(--color-accent);
   margin: var(--font-size-1) 0;
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-gray) transparent;
 }
 
 .sections-list {

--- a/src/components/capabilities/capabilities.css
+++ b/src/components/capabilities/capabilities.css
@@ -42,8 +42,8 @@
   border: 2px dotted var(--color-accent);
 }
 
-.section:hover strong,
-.active strong {
+.active strong,
+.section:hover strong {
   font-family: var(--font-primary-bold);
   color: var(--color-white);
 }

--- a/src/components/copy-to-clipboard/copy-to-clipboard.css
+++ b/src/components/copy-to-clipboard/copy-to-clipboard.css
@@ -1,5 +1,4 @@
 #icon {
-  background-color: transparent;
   padding: var(--size-2);
   border: none;
   cursor: pointer;

--- a/src/components/footer/footer.module.css
+++ b/src/components/footer/footer.module.css
@@ -10,7 +10,6 @@
   padding-left: var(--size-fluid-1);
   display: flex;
   flex-direction: column;
-  flex-basis: 100%;
   flex: 1;
   justify-content: center;
   color: var(--color-gray);

--- a/src/components/header/header.module.css
+++ b/src/components/header/header.module.css
@@ -45,6 +45,11 @@
   color: var(--color-black);
 }
 
+.mobileMenuListItem a {
+  color: var(--color-black);
+  text-decoration: none;
+}
+
 .navBarMenuItem a:hover {
   text-decoration: underline;
 }
@@ -108,10 +113,10 @@
   font-size: var(--font-size-5);
 }
 
-.mobileMenuListItem a {
+/* .mobileMenuListItem a {
   color: var(--color-black);
   text-decoration: none;
-}
+} */
 
 @media screen and (min-width: 480px) {
   .container {

--- a/src/components/header/header.module.css
+++ b/src/components/header/header.module.css
@@ -113,11 +113,6 @@
   font-size: var(--font-size-5);
 }
 
-/* .mobileMenuListItem a {
-  color: var(--color-black);
-  text-decoration: none;
-} */
-
 @media screen and (min-width: 480px) {
   .container {
     justify-content: space-between;

--- a/src/components/hero-banner/hero-banner.module.css
+++ b/src/components/hero-banner/hero-banner.module.css
@@ -84,11 +84,9 @@
 
 .snippet pre {
   font-size: 16px;
-  display: inline-block;
   height: 46px;
   align-content: center;
   display: inline;
-  vertical-align: text-top;
   background-color: transparent;
   color: var(--color-black);
   vertical-align: middle;

--- a/src/components/side-nav/side-nav.module.css
+++ b/src/components/side-nav/side-nav.module.css
@@ -8,10 +8,6 @@
     color: var(--color-black);
     text-decoration: none;
   }
-
-  & a:hover {
-    opacity: 0.7;
-  }
 }
 
 .compactMenuCloseButton {
@@ -54,6 +50,19 @@
   height: auto;
 }
 
+.compactMenuSectionListItemActive {
+  & a {
+    border-left: var(--size-1) solid black;
+    border-radius: var(--radius-2);
+    background-color: white;
+    padding: 0 var(--size-2);
+    min-width: 200px;
+    display: inline-block;
+    box-shadow: var(--shadow-3);
+    margin-left: -16px;
+  }
+}
+
 .compactMenuSectionHeading {
   margin: 0 0 var(--size-2) 0;
 
@@ -64,6 +73,7 @@
   & a.active,
   & a:hover {
     text-decoration: underline;
+    opacity: 0.7;
   }
 
   & a.active::before {
@@ -77,19 +87,6 @@
 
   & a:hover {
     opacity: 0.7;
-  }
-}
-
-.compactMenuSectionListItemActive {
-  & a {
-    border-left: var(--size-1) solid black;
-    border-radius: var(--radius-2);
-    background-color: white;
-    padding: 0 var(--size-2);
-    min-width: 200px;
-    display: inline-block;
-    box-shadow: var(--shadow-3);
-    margin-left: -16px;
   }
 }
 

--- a/src/components/side-nav/side-nav.module.css
+++ b/src/components/side-nav/side-nav.module.css
@@ -60,9 +60,7 @@
   & a {
     font-family: var(--font-primary-bold);
   }
-}
 
-.compactMenuSectionHeading {
   & a.active,
   & a:hover {
     text-decoration: underline;

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -1,6 +1,3 @@
 export default {
-  // no stylelint 16 support yet
-  // https://github.com/developer-stylechain/stylelint-a11y/issues/4
-  // plugins: ['stylelint-a11y'],
-  extends: ["stylelint-prettier/recommended"],
+  extends: ["stylelint-config-recommended"],
 };


### PR DESCRIPTION
## Related Issue

Fix #51 

## Summary of Changes

- Refactor lint-staged config to run library exec directly

Some Notes on lint-staged:
- Running a sequence requires an array - https://www.npmjs.com/package/lint-staged/v/12.3.2#running-multiple-commands-in-a-sequence
- Reusing npm scripts seem to require a trailing "`--`" - https://www.npmjs.com/package/lint-staged/v/12.3.2#reuse-npm-script
- When filtering files, using a leading `/` will change how the glob works to identify the files. - https://www.npmjs.com/package/lint-staged/v/12.3.2#filtering-files
    - _If the glob pattern contains no slashes (/), micromatch's matchBase option will enabled, so globs match a file's basename regardless of directory_
    - _If the glob pattern does contain a slash (/), it will match for paths as well_

## Error Report 

This is after the `stylelint-config-recommended` update

```
src/components/capabilities/capabilities.css
  44:1  ✖  Expected selector ".active strong" to come before selector ".section:hover strong"  no-descending-specificity
  70:1  ✖  Unexpected duplicate selector ".heading", first used at line 12                     no-duplicate-selectors
  88:1  ✖  Unexpected duplicate selector ".sections", first used at line 21                    no-duplicate-selectors

src/components/copy-to-clipboard/copy-to-clipboard.css
  7:3  ✖  Unexpected duplicate "background-color"  declaration-block-no-duplicate-properties

src/components/footer/footer.module.css
  14:3  ✖  Unexpected shorthand "flex" after "flex-basis"  declaration-block-no-shorthand-property-overrides

src/components/header/header.module.css
  111:1  ✖  Expected selector ".mobileMenuListItem a" to come before selector ".navBarMenuItem a:hover"  no-descending-specificity

src/components/hero-banner/hero-banner.module.css
  90:3  ✖  Unexpected duplicate "display"         declaration-block-no-duplicate-properties
  94:3  ✖  Unexpected duplicate "vertical-align"  declaration-block-no-duplicate-properties

src/components/side-nav/side-nav.module.css
  60:3  ✖  Expected selector ".compactMenuSectionHeading a" to come before selector ".compactMenu a:hover"         no-descending-specificity
  65:1  ✖  Unexpected duplicate selector ".compactMenuSectionHeading", first used at line 57                       no-duplicate-selectors
  86:3  ✖  Expected selector ".compactMenuSectionListItemActive a" to come before selector ".compactMenu a:hover"  no-descending-specificity

✖ 11 problems (11 errors, 0 warnings)
  3 errors potentially fixable with the "--fix" option.
```


From comment https://github.com/ProjectEvergreen/www.greenwoodjs.dev/pull/112#discussion_r1805098246

- [x] Swap out stylelint-prettier/recommended (config and dependency) with stylelint-config-recommended in stylelint.config.js -- https://github.com/ProjectEvergreen/www.greenwoodjs.dev/pull/112/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R77
- [x] Fix up any new CSS linting checks / sanity test UI
- [x] tweak link staged tasks to reflect original intent + best practices -- https://github.com/ProjectEvergreen/www.greenwoodjs.dev/pull/112/files#diff-29c15f0b5d8d1144bd22153c302cde16c2de092d65b122a618cbdb3023336346R2-R4
- [x] (bonus / optional / whatever) put lint-staged config in its own [config file](https://www.npmjs.com/package/lint-staged/v/12.3.2#configuration) -- https://github.com/ProjectEvergreen/www.greenwoodjs.dev/blob/71a56b2e8b3a810da0513e9c383746a4edfd341e/lint-staged.config.js