### PR TITLE
bug/issue 30 restore click target to home page npx CTA

### DIFF
--- a/src/components/hero-banner/hero-banner.module.css
+++ b/src/components/hero-banner/hero-banner.module.css
@@ -100,6 +100,7 @@
   display: none;
   vertical-align: middle;
   margin-left: -60px;
+  pointer-events: none;
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

seems to be a regression introduced from #101 , in that the green `npx` CTA (call-to-action) wasn't clickable (being covered by the emphasis corner image)


https://github.com/user-attachments/assets/5bf7d3f5-13ea-45e9-bee1-17c8fb3f5459

## Summary of Changes

1. Set `pointer-events: none` to the emphasis corner SVG element to avoid it from covering the icon button