### PR TITLE
enhancement/issue 88 header navigation using content as data

### DIFF
--- a/src/components/header/header.js
+++ b/src/components/header/header.js
@@ -1,4 +1,4 @@
-import { getContentByCollection } from "@greenwood/cli/src/data/queries.js";
+import { getContentByCollection } from "@greenwood/cli/src/data/client.js";
 import discordIcon from "../../assets/discord.svg?type=raw";
 import githubIcon from "../../assets/github.svg?type=raw";
 import twitterIcon from "../../assets/twitter-logo.svg?type=raw";

--- a/src/components/header/header.js
+++ b/src/components/header/header.js
@@ -1,3 +1,4 @@
+import { getContentByCollection } from "@greenwood/cli/src/data/queries.js";
 import discordIcon from "../../assets/discord.svg?type=raw";
 import githubIcon from "../../assets/github.svg?type=raw";
 import twitterIcon from "../../assets/twitter-logo.svg?type=raw";
@@ -6,7 +7,11 @@ import greenwoodLogo from "../../assets/greenwood-logo-full.svg?type=raw";
 import styles from "./header.module.css";
 
 export default class Header extends HTMLElement {
-  connectedCallback() {
+  async connectedCallback() {
+    const navItems = (await getContentByCollection("nav")).sort((a, b) =>
+      a.data.order > b.data.order ? 1 : -1,
+    );
+
     this.innerHTML = `
       <header class="${styles.container}">
         <a href="/" title="Greenwood Home Page" class="${styles.logoLink}">
@@ -16,15 +21,17 @@ export default class Header extends HTMLElement {
         <div class="${styles.navBar}">
           <nav role="navigation" aria-label="Main">
             <ul class="${styles.navBarMenu}">
-              <li class="${styles.navBarMenuItem}">
-                <a href="/docs/" title="Documentation">Docs</a>
-              </li>
-              <li class="${styles.navBarMenuItem}">
-                <a href="/guides/" title="Guides">Guides</a>
-              </li>
-              <li class="${styles.navBarMenuItem}">
-                <a href="/blog/" title="Blog">Blog</a>
-              </li>
+              ${navItems
+                .map((item) => {
+                  const { route, label } = item;
+
+                  return `
+                  <li class="${styles.navBarMenuItem}">
+                    <a href="${route}" title="${label}">${label}</a>
+                  </li>
+                `;
+                })
+                .join("")}
             </ul>
           </nav>
 
@@ -64,15 +71,17 @@ export default class Header extends HTMLElement {
             
             <nav role="navigation" aria-label="Mobile">
               <ul class="${styles.mobileMenuList}">
-                <li class="${styles.mobileMenuListItem}">
-                  <a href="/docs/" title="Documentation">Docs</a>
-                </li>
-                <li class="${styles.mobileMenuListItem}">
-                  <a href="/guides/" title="Guides">Guides</a>
-                </li>
-                <li class="${styles.mobileMenuListItem}">
-                  <a href="/blog/" title="Blog">Blog</a>
-                </li>
+                ${navItems
+                  .map((item) => {
+                    const { route, label } = item;
+
+                    return `
+                    <li class="${styles.mobileMenuListItem}">
+                      <a href="${route}" title="${label}">${label}</a>
+                    </li>
+                  `;
+                  })
+                  .join("")}
               </ul>
             </nav>
           </div>

--- a/src/components/header/header.js
+++ b/src/components/header/header.js
@@ -8,6 +8,7 @@ import styles from "./header.module.css";
 
 export default class Header extends HTMLElement {
   async connectedCallback() {
+    const currentRoute = this.getAttribute("current-route") ?? "";
     const navItems = (await getContentByCollection("nav")).sort((a, b) =>
       a.data.order > b.data.order ? 1 : -1,
     );
@@ -24,12 +25,13 @@ export default class Header extends HTMLElement {
               ${navItems
                 .map((item) => {
                   const { route, label } = item;
+                  const isActiveClass = currentRoute.startsWith(item.route) ? 'class="active"' : "";
 
                   return `
-                  <li class="${styles.navBarMenuItem}">
-                    <a href="${route}" title="${label}">${label}</a>
-                  </li>
-                `;
+                    <li class="${styles.navBarMenuItem}">
+                      <a href="${route}" ${isActiveClass} title="${label}">${label}</a>
+                    </li>
+                  `;
                 })
                 .join("")}
             </ul>
@@ -74,12 +76,15 @@ export default class Header extends HTMLElement {
                 ${navItems
                   .map((item) => {
                     const { route, label } = item;
+                    const isActiveClass = currentRoute.startsWith(item.route)
+                      ? 'class="active"'
+                      : "";
 
                     return `
-                    <li class="${styles.mobileMenuListItem}">
-                      <a href="${route}" title="${label}">${label}</a>
-                    </li>
-                  `;
+                      <li class="${styles.mobileMenuListItem}">
+                        <a href="${route}" ${isActiveClass} title="${label}">${label}</a>
+                      </li>
+                    `;
                   })
                   .join("")}
               </ul>

--- a/src/components/header/header.module.css
+++ b/src/components/header/header.module.css
@@ -40,6 +40,11 @@
   padding: 0;
 }
 
+.mobileMenuList {
+  text-align: left;
+  margin: var(--size-4) 0 0;
+}
+
 .navBarMenuItem a {
   text-decoration: none;
   color: var(--color-black);
@@ -50,8 +55,19 @@
   text-decoration: none;
 }
 
+.navBarMenuItem a.active,
 .navBarMenuItem a:hover,
 .navBarMenuItem a:focus {
+  text-decoration: underline;
+}
+
+.mobileMenuListItem {
+  list-style-type: none;
+  margin: 10px 0;
+  font-size: var(--font-size-5);
+}
+
+.mobileMenuListItem a.active {
   text-decoration: underline;
 }
 
@@ -101,17 +117,6 @@
   border: none;
   padding: 0 12px;
   color: var(--color-black);
-}
-
-.mobileMenuList {
-  text-align: left;
-  margin: var(--size-4) 0 0;
-}
-
-.mobileMenuListItem {
-  list-style-type: none;
-  margin: 10px 0;
-  font-size: var(--font-size-5);
 }
 
 @media screen and (min-width: 480px) {

--- a/src/components/header/header.spec.js
+++ b/src/components/header/header.spec.js
@@ -2,6 +2,7 @@ import { expect } from "@esm-bundle/chai";
 import "./header.js";
 import pages from "../../stories/mocks/graph.json" with { type: "json" };
 
+const CURRENT_ROUTE = "/guides/";
 const ICONS = [
   {
     link: "https://github.com/ProjectEvergreen/greenwood",
@@ -28,6 +29,8 @@ describe("Components/Header", () => {
 
   before(async () => {
     header = document.createElement("app-header");
+    header.setAttribute("current-route", CURRENT_ROUTE);
+
     document.body.appendChild(header);
 
     await header.updateComplete;
@@ -55,6 +58,7 @@ describe("Components/Header", () => {
 
     it("should have the expected desktop navigation links", () => {
       const links = header.querySelectorAll("nav[aria-label='Main'] ul li a");
+      let activeRoute = undefined;
 
       Array.from(links).forEach((link, idx) => {
         const navItem = pages.find((nav) => nav.route === link.getAttribute("href"));
@@ -63,6 +67,13 @@ describe("Components/Header", () => {
         expect(navItem.data.order).to.equal((idx += 1));
         expect(link.textContent).to.equal(navItem.label);
         expect(link.getAttribute("title")).to.equal(navItem.title);
+
+        // current route should display as active
+        if (navItem.route === CURRENT_ROUTE && link.getAttribute("class").includes("active")) {
+          activeRoute = navItem;
+        }
+
+        expect(activeRoute.route).to.equal(CURRENT_ROUTE);
       });
     });
 
@@ -113,6 +124,7 @@ describe("Components/Header", () => {
 
     it("should have the expected navigation links", () => {
       const links = header.querySelectorAll("nav[aria-label='Mobile'] ul li a");
+      let activeRoute = undefined;
 
       Array.from(links).forEach((link, idx) => {
         const navItem = pages.find((nav) => nav.route === link.getAttribute("href"));
@@ -121,7 +133,14 @@ describe("Components/Header", () => {
         expect(navItem.data.order).to.equal((idx += 1));
         expect(link.textContent).to.equal(navItem.label);
         expect(link.getAttribute("title")).to.equal(navItem.title);
+
+        // current route should display as active
+        if (navItem.route === CURRENT_ROUTE && link.getAttribute("class").includes("active")) {
+          activeRoute = navItem;
+        }
       });
+
+      expect(activeRoute.route).to.equal(CURRENT_ROUTE);
     });
   });
 

--- a/src/components/header/header.spec.js
+++ b/src/components/header/header.spec.js
@@ -20,7 +20,7 @@ const ICONS = [
 
 window.fetch = function () {
   return new Promise((resolve) => {
-    resolve(new Response(JSON.stringify(pages)));
+    resolve(new Response(JSON.stringify(pages.filter((page) => page.data.collection === "nav"))));
   });
 };
 
@@ -72,9 +72,9 @@ describe("Components/Header", () => {
         if (navItem.route === CURRENT_ROUTE && link.getAttribute("class").includes("active")) {
           activeRoute = navItem;
         }
-
-        expect(activeRoute.route).to.equal(CURRENT_ROUTE);
       });
+
+      expect(activeRoute.route).to.equal(CURRENT_ROUTE);
     });
 
     it("should have the expected social link icons", () => {

--- a/src/components/header/header.spec.js
+++ b/src/components/header/header.spec.js
@@ -1,36 +1,29 @@
 import { expect } from "@esm-bundle/chai";
 import "./header.js";
+import pages from "../../stories/mocks/graph.json" with { type: "json" };
+
+const ICONS = [
+  {
+    link: "https://github.com/ProjectEvergreen/greenwood",
+    title: "GitHub",
+  },
+  {
+    link: "https://discord.gg/bsy9jvWh",
+    title: "Discord",
+  },
+  {
+    link: "https://twitter.com/PrjEvergreen",
+    title: "Twitter",
+  },
+];
+
+window.fetch = function () {
+  return new Promise((resolve) => {
+    resolve(new Response(JSON.stringify(pages)));
+  });
+};
 
 describe("Components/Header", () => {
-  const NAV = [
-    {
-      title: "Documentation",
-      label: "Docs",
-    },
-    {
-      title: "Guides",
-      label: "Guides",
-    },
-    {
-      title: "Blog",
-      label: "Blog",
-    },
-  ];
-  const ICONS = [
-    {
-      link: "https://github.com/ProjectEvergreen/greenwood",
-      title: "GitHub",
-    },
-    {
-      link: "https://discord.gg/bsy9jvWh",
-      title: "Discord",
-    },
-    {
-      link: "https://twitter.com/PrjEvergreen",
-      title: "Twitter",
-    },
-  ];
-
   let header;
 
   before(async () => {
@@ -63,12 +56,11 @@ describe("Components/Header", () => {
     it("should have the expected desktop navigation links", () => {
       const links = header.querySelectorAll("nav[aria-label='Main'] ul li a");
 
-      Array.from(links).forEach((link) => {
-        const navItem = NAV.find(
-          (nav) => `/${nav.label.toLowerCase()}/` === link.getAttribute("href"),
-        );
+      Array.from(links).forEach((link, idx) => {
+        const navItem = pages.find((nav) => nav.route === link.getAttribute("href"));
 
         expect(navItem).to.not.equal(undefined);
+        expect(navItem.data.order).to.equal((idx += 1));
         expect(link.textContent).to.equal(navItem.label);
         expect(link.getAttribute("title")).to.equal(navItem.title);
       });
@@ -122,12 +114,11 @@ describe("Components/Header", () => {
     it("should have the expected navigation links", () => {
       const links = header.querySelectorAll("nav[aria-label='Mobile'] ul li a");
 
-      Array.from(links).forEach((link) => {
-        const navItem = NAV.find(
-          (nav) => `/${nav.label.toLowerCase()}/` === link.getAttribute("href"),
-        );
+      Array.from(links).forEach((link, idx) => {
+        const navItem = pages.find((nav) => nav.route === link.getAttribute("href"));
 
         expect(navItem).to.not.equal(undefined);
+        expect(navItem.data.order).to.equal((idx += 1));
         expect(link.textContent).to.equal(navItem.label);
         expect(link.getAttribute("title")).to.equal(navItem.title);
       });

--- a/src/components/header/header.stories.js
+++ b/src/components/header/header.stories.js
@@ -19,6 +19,6 @@ export default {
   },
 };
 
-const Template = () => "<app-header></app-header>";
+const Template = () => "<app-header current-route='/guides/'></app-header>";
 
 export const Primary = Template.bind({});

--- a/src/components/header/header.stories.js
+++ b/src/components/header/header.stories.js
@@ -8,9 +8,9 @@ export default {
       mocks: [
         {
           matcher: {
-            url: "http://localhost:1985/graph.json",
+            url: "http://localhost:1984/___graph.json",
             response: {
-              body: pages,
+              body: pages.filter((page) => page.data.collection === "nav"),
             },
           },
         },

--- a/src/components/header/header.stories.js
+++ b/src/components/header/header.stories.js
@@ -1,7 +1,22 @@
 import "./header.js";
+import pages from "../../stories/mocks/graph.json";
 
 export default {
   title: "Components/Header",
+  parameters: {
+    fetchMock: {
+      mocks: [
+        {
+          matcher: {
+            url: "http://localhost:1985/graph.json",
+            response: {
+              body: pages,
+            },
+          },
+        },
+      ],
+    },
+  },
 };
 
 const Template = () => "<app-header></app-header>";

--- a/src/layouts/app.html
+++ b/src/layouts/app.html
@@ -28,7 +28,7 @@
   </head>
 
   <body>
-    <app-header></app-header>
+    <app-header current-route="${globalThis.page.route}"></app-header>
 
     <main class="page-content">
       <page-outlet></page-outlet>

--- a/src/pages/blog/index.html
+++ b/src/pages/blog/index.html
@@ -1,3 +1,8 @@
+---
+collection: nav
+order: 3
+---
+
 <html>
   <head>
     <title>Greenwood - ${globalThis.page.title}</title>

--- a/src/pages/docs/index.md
+++ b/src/pages/docs/index.md
@@ -1,6 +1,8 @@
 ---
 title: Docs
 layout: docs
+collection: nav
+order: 1
 ---
 
 <app-heading-box heading="Docs">

--- a/src/pages/guides/index.md
+++ b/src/pages/guides/index.md
@@ -1,6 +1,8 @@
 ---
 title: Guides
 layout: guides
+collection: nav
+order: 2
 ---
 
 <app-heading-box heading="Guides">

--- a/src/stories/mocks/graph.json
+++ b/src/stories/mocks/graph.json
@@ -4,12 +4,18 @@
     "title": null,
     "route": "/blog/",
     "layout": null,
-    "data": {
-      "tocHeading": 0,
-      "tableOfContents": []
-    },
+    "data": { "collection": "nav", "order": 3, "tocHeading": 0, "tableOfContents": [] },
     "imports": [],
-    "resources": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/blog-posts-list/blog-posts-list.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1494238925.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css"
+    ],
     "pagePath": "./blog/index.html",
     "outputPath": "/blog/index.html",
     "isSSR": false,
@@ -30,7 +36,15 @@
       "tableOfContents": []
     },
     "imports": [],
-    "resources": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/blog.css"
+    ],
     "pagePath": "./blog/release/v0-15-0.md",
     "outputPath": "/blog/release/v0-15-0/index.html",
     "isSSR": false,
@@ -51,7 +65,15 @@
       "tableOfContents": []
     },
     "imports": [],
-    "resources": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/blog.css"
+    ],
     "pagePath": "./blog/release/v0-18-0.md",
     "outputPath": "/blog/release/v0-18-0/index.html",
     "isSSR": false,
@@ -72,7 +94,15 @@
       "tableOfContents": []
     },
     "imports": [],
-    "resources": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/blog.css"
+    ],
     "pagePath": "./blog/release/v0-19-0.md",
     "outputPath": "/blog/release/v0-19-0/index.html",
     "isSSR": false,
@@ -94,7 +124,15 @@
       "tableOfContents": []
     },
     "imports": [],
-    "resources": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/blog.css"
+    ],
     "pagePath": "./blog/release/v0-20-0.md",
     "outputPath": "/blog/release/v0-20-0/index.html",
     "isSSR": false,
@@ -115,7 +153,15 @@
       "tableOfContents": []
     },
     "imports": [],
-    "resources": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/blog.css"
+    ],
     "pagePath": "./blog/release/v0-21-0.md",
     "outputPath": "/blog/release/v0-21-0/index.html",
     "isSSR": false,
@@ -136,7 +182,15 @@
       "tableOfContents": []
     },
     "imports": [],
-    "resources": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/blog.css"
+    ],
     "pagePath": "./blog/release/v0-23-0.md",
     "outputPath": "/blog/release/v0-23-0/index.html",
     "isSSR": false,
@@ -157,7 +211,15 @@
       "tableOfContents": []
     },
     "imports": [],
-    "resources": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/blog.css"
+    ],
     "pagePath": "./blog/release/v0-24-0.md",
     "outputPath": "/blog/release/v0-24-0/index.html",
     "isSSR": false,
@@ -179,7 +241,16 @@
       "tableOfContents": []
     },
     "imports": [],
-    "resources": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/339602163.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/blog.css"
+    ],
     "pagePath": "./blog/release/v0-26-0.md",
     "outputPath": "/blog/release/v0-26-0/index.html",
     "isSSR": false,
@@ -201,7 +272,16 @@
       "tableOfContents": []
     },
     "imports": [],
-    "resources": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/865966005.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/blog.css"
+    ],
     "pagePath": "./blog/release/v0-27-0.md",
     "outputPath": "/blog/release/v0-27-0/index.html",
     "isSSR": false,
@@ -223,7 +303,15 @@
       "tableOfContents": []
     },
     "imports": [],
-    "resources": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/blog.css"
+    ],
     "pagePath": "./blog/release/v0-28-0.md",
     "outputPath": "/blog/release/v0-28-0/index.html",
     "isSSR": false,
@@ -245,7 +333,15 @@
       "tableOfContents": []
     },
     "imports": [],
-    "resources": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/blog.css"
+    ],
     "pagePath": "./blog/release/v0-29-0.md",
     "outputPath": "/blog/release/v0-29-0/index.html",
     "isSSR": false,
@@ -267,7 +363,15 @@
       "tableOfContents": []
     },
     "imports": [],
-    "resources": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/blog.css"
+    ],
     "pagePath": "./blog/state-of-greenwood-2022.md",
     "outputPath": "/blog/state-of-greenwood-2022/index.html",
     "isSSR": false,
@@ -289,7 +393,15 @@
       "tableOfContents": []
     },
     "imports": [],
-    "resources": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/blog.css"
+    ],
     "pagePath": "./blog/state-of-greenwood-2023.md",
     "outputPath": "/blog/state-of-greenwood-2023/index.html",
     "isSSR": false,
@@ -307,24 +419,24 @@
       "order": 2,
       "tocHeading": 2,
       "tableOfContents": [
-        {
-          "content": "Installation",
-          "slug": "installation",
-          "lvl": 2,
-          "i": 1,
-          "seen": 0
-        },
-        {
-          "content": "Example",
-          "slug": "example",
-          "lvl": 2,
-          "i": 2,
-          "seen": 0
-        }
+        { "content": "Installation", "slug": "installation", "lvl": 2, "i": 1, "seen": 0 },
+        { "content": "Example", "slug": "example", "lvl": 2, "i": 2, "seen": 0 }
       ]
     },
     "imports": [],
-    "resources": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/884562519.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css"
+    ],
     "pagePath": "./guides/ecosystem/htmx.md",
     "outputPath": "/guides/ecosystem/htmx/index.html",
     "isSSR": false,
@@ -338,13 +450,21 @@
     "title": null,
     "route": "/guides/ecosystem/",
     "layout": "guides",
-    "data": {
-      "order": 3,
-      "tocHeading": 0,
-      "tableOfContents": []
-    },
+    "data": { "order": 3, "tocHeading": 0, "tableOfContents": [] },
     "imports": [],
-    "resources": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/884562519.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css"
+    ],
     "pagePath": "./guides/ecosystem/index.md",
     "outputPath": "/guides/ecosystem/index.html",
     "isSSR": false,
@@ -362,24 +482,24 @@
       "order": 1,
       "tocHeading": 2,
       "tableOfContents": [
-        {
-          "content": "Installation",
-          "slug": "installation",
-          "lvl": 2,
-          "i": 1,
-          "seen": 0
-        },
-        {
-          "content": "SSR",
-          "slug": "ssr",
-          "lvl": 2,
-          "i": 2,
-          "seen": 0
-        }
+        { "content": "Installation", "slug": "installation", "lvl": 2, "i": 1, "seen": 0 },
+        { "content": "SSR", "slug": "ssr", "lvl": 2, "i": 2, "seen": 0 }
       ]
     },
     "imports": [],
-    "resources": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/884562519.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css"
+    ],
     "pagePath": "./guides/ecosystem/lit.md",
     "outputPath": "/guides/ecosystem/lit/index.html",
     "isSSR": false,
@@ -397,38 +517,34 @@
       "order": 4,
       "tocHeading": 2,
       "tableOfContents": [
+        { "content": "Setup", "slug": "setup", "lvl": 2, "i": 1, "seen": 0 },
+        { "content": "Usage", "slug": "usage", "lvl": 2, "i": 2, "seen": 0 },
+        { "content": "Static Assets", "slug": "static-assets", "lvl": 2, "i": 3, "seen": 0 },
         {
-          "content": "Installation",
-          "slug": "installation",
-          "lvl": 2,
-          "i": 1,
-          "seen": 0
-        },
-        {
-          "content": "Vite Config",
-          "slug": "vite-config",
-          "lvl": 2,
-          "i": 2,
-          "seen": 0
-        },
-        {
-          "content": "Custom Resources",
-          "slug": "custom-resources",
-          "lvl": 2,
-          "i": 3,
-          "seen": 0
-        },
-        {
-          "content": "Usage",
-          "slug": "usage",
+          "content": "Import Attributes",
+          "slug": "import-attributes",
           "lvl": 2,
           "i": 4,
           "seen": 0
-        }
+        },
+        { "content": "Resource Plugins", "slug": "resource-plugins", "lvl": 2, "i": 5, "seen": 0 },
+        { "content": "Content as Data", "slug": "content-as-data", "lvl": 2, "i": 6, "seen": 0 }
       ]
     },
     "imports": [],
-    "resources": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/884562519.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css"
+    ],
     "pagePath": "./guides/ecosystem/storybook.md",
     "outputPath": "/guides/ecosystem/storybook/index.html",
     "isSSR": false,
@@ -446,24 +562,24 @@
       "order": 3,
       "tocHeading": 2,
       "tableOfContents": [
-        {
-          "content": "Installation",
-          "slug": "installation",
-          "lvl": 2,
-          "i": 1,
-          "seen": 0
-        },
-        {
-          "content": "Usage",
-          "slug": "usage",
-          "lvl": 2,
-          "i": 2,
-          "seen": 0
-        }
+        { "content": "Installation", "slug": "installation", "lvl": 2, "i": 1, "seen": 0 },
+        { "content": "Usage", "slug": "usage", "lvl": 2, "i": 2, "seen": 0 }
       ]
     },
     "imports": [],
-    "resources": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/884562519.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css"
+    ],
     "pagePath": "./guides/ecosystem/tailwind.md",
     "outputPath": "/guides/ecosystem/tailwind/index.html",
     "isSSR": false,
@@ -481,31 +597,27 @@
       "order": 5,
       "tocHeading": 2,
       "tableOfContents": [
-        {
-          "content": "Installation",
-          "slug": "installation",
-          "lvl": 2,
-          "i": 1,
-          "seen": 0
-        },
-        {
-          "content": "Custom Resources",
-          "slug": "custom-resources",
-          "lvl": 2,
-          "i": 2,
-          "seen": 0
-        },
-        {
-          "content": "Usage",
-          "slug": "usage",
-          "lvl": 2,
-          "i": 3,
-          "seen": 0
-        }
+        { "content": "Setup", "slug": "setup", "lvl": 2, "i": 1, "seen": 0 },
+        { "content": "Usage", "slug": "usage", "lvl": 2, "i": 2, "seen": 0 },
+        { "content": "Static Assets", "slug": "static-assets", "lvl": 2, "i": 3, "seen": 0 },
+        { "content": "Resource Plugins", "slug": "resource-plugins", "lvl": 2, "i": 4, "seen": 0 },
+        { "content": "Content as Data", "slug": "content-as-data", "lvl": 2, "i": 5, "seen": 0 }
       ]
     },
     "imports": [],
-    "resources": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/884562519.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css"
+    ],
     "pagePath": "./guides/ecosystem/web-test-runner.md",
     "outputPath": "/guides/ecosystem/web-test-runner/index.html",
     "isSSR": false,
@@ -523,45 +635,26 @@
       "order": 3,
       "tocHeading": 2,
       "tableOfContents": [
-        {
-          "content": "Prerendering",
-          "slug": "prerendering",
-          "lvl": 2,
-          "i": 1,
-          "seen": 0
-        },
-        {
-          "content": "Light vs Shadow DOM",
-          "slug": "light-vs-shadow-dom",
-          "lvl": 2,
-          "i": 2,
-          "seen": 0
-        },
-        {
-          "content": "Content as Data",
-          "slug": "content-as-data",
-          "lvl": 2,
-          "i": 3,
-          "seen": 0
-        },
-        {
-          "content": "Plugins",
-          "slug": "plugins",
-          "lvl": 2,
-          "i": 4,
-          "seen": 0
-        },
-        {
-          "content": "Next Section",
-          "slug": "next-section",
-          "lvl": 2,
-          "i": 5,
-          "seen": 0
-        }
+        { "content": "Prerendering", "slug": "prerendering", "lvl": 2, "i": 1, "seen": 0 },
+        { "content": "Light DOM", "slug": "light-dom", "lvl": 2, "i": 2, "seen": 0 },
+        { "content": "Content as Data", "slug": "content-as-data", "lvl": 2, "i": 3, "seen": 0 },
+        { "content": "Next Section", "slug": "next-section", "lvl": 2, "i": 4, "seen": 0 }
       ]
     },
     "imports": [],
-    "resources": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/884562519.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css"
+    ],
     "pagePath": "./guides/getting-started/going-further.md",
     "outputPath": "/guides/getting-started/going-further/index.html",
     "isSSR": false,
@@ -579,45 +672,27 @@
       "order": 1,
       "tocHeading": 2,
       "tableOfContents": [
-        {
-          "content": "What to Expect",
-          "slug": "what-to-expect",
-          "lvl": 2,
-          "i": 0,
-          "seen": 0
-        },
-        {
-          "content": "Prerequisites",
-          "slug": "prerequisites",
-          "lvl": 2,
-          "i": 1,
-          "seen": 0
-        },
-        {
-          "content": "Setup",
-          "slug": "setup",
-          "lvl": 2,
-          "i": 2,
-          "seen": 0
-        },
-        {
-          "content": "Jump Right In",
-          "slug": "jump-right-in",
-          "lvl": 2,
-          "i": 3,
-          "seen": 0
-        },
-        {
-          "content": "Next Section",
-          "slug": "next-section",
-          "lvl": 2,
-          "i": 4,
-          "seen": 0
-        }
+        { "content": "What to Expect", "slug": "what-to-expect", "lvl": 2, "i": 0, "seen": 0 },
+        { "content": "Prerequisites", "slug": "prerequisites", "lvl": 2, "i": 1, "seen": 0 },
+        { "content": "Setup", "slug": "setup", "lvl": 2, "i": 2, "seen": 0 },
+        { "content": "Jump Right In", "slug": "jump-right-in", "lvl": 2, "i": 3, "seen": 0 },
+        { "content": "Next Section", "slug": "next-section", "lvl": 2, "i": 4, "seen": 0 }
       ]
     },
     "imports": [],
-    "resources": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/884562519.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css"
+    ],
     "pagePath": "./guides/getting-started/index.md",
     "outputPath": "/guides/getting-started/index.html",
     "isSSR": false,
@@ -642,13 +717,7 @@
           "i": 1,
           "seen": 0
         },
-        {
-          "content": "Pages",
-          "slug": "pages",
-          "lvl": 2,
-          "i": 2,
-          "seen": 0
-        },
+        { "content": "Pages", "slug": "pages", "lvl": 2, "i": 2, "seen": 0 },
         {
           "content": "Scripts and Styles",
           "slug": "scripts-and-styles",
@@ -656,13 +725,7 @@
           "i": 3,
           "seen": 0
         },
-        {
-          "content": "Layouts",
-          "slug": "layouts",
-          "lvl": 2,
-          "i": 4,
-          "seen": 0
-        },
+        { "content": "Layouts", "slug": "layouts", "lvl": 2, "i": 4, "seen": 0 },
         {
           "content": "Markdown and Frontmatter",
           "slug": "markdown-and-frontmatter",
@@ -670,17 +733,23 @@
           "i": 5,
           "seen": 0
         },
-        {
-          "content": "Next Section",
-          "slug": "next-section",
-          "lvl": 2,
-          "i": 6,
-          "seen": 0
-        }
+        { "content": "Next Section", "slug": "next-section", "lvl": 2, "i": 6, "seen": 0 }
       ]
     },
     "imports": [],
-    "resources": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/884562519.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css"
+    ],
     "pagePath": "./guides/getting-started/key-concepts.md",
     "outputPath": "/guides/getting-started/key-concepts/index.html",
     "isSSR": false,
@@ -694,13 +763,21 @@
     "title": null,
     "route": "/guides/getting-started/next-steps/",
     "layout": "guides",
-    "data": {
-      "order": 4,
-      "tocHeading": 2,
-      "tableOfContents": []
-    },
+    "data": { "order": 4, "tocHeading": 2, "tableOfContents": [] },
     "imports": [],
-    "resources": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/884562519.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css"
+    ],
     "pagePath": "./guides/getting-started/next-steps.md",
     "outputPath": "/guides/getting-started/next-steps/index.html",
     "isSSR": false,
@@ -725,45 +802,27 @@
           "i": 1,
           "seen": 0
         },
-        {
-          "content": "Creating Content",
-          "slug": "creating-content",
-          "lvl": 2,
-          "i": 2,
-          "seen": 0
-        },
-        {
-          "content": "Styling",
-          "slug": "styling",
-          "lvl": 2,
-          "i": 7,
-          "seen": 0
-        },
-        {
-          "content": "Components",
-          "slug": "components",
-          "lvl": 2,
-          "i": 8,
-          "seen": 0
-        },
-        {
-          "content": "Final Build",
-          "slug": "final-build",
-          "lvl": 2,
-          "i": 9,
-          "seen": 0
-        },
-        {
-          "content": "Next Section",
-          "slug": "next-section",
-          "lvl": 2,
-          "i": 10,
-          "seen": 0
-        }
+        { "content": "Creating Content", "slug": "creating-content", "lvl": 2, "i": 2, "seen": 0 },
+        { "content": "Styling", "slug": "styling", "lvl": 2, "i": 7, "seen": 0 },
+        { "content": "Components", "slug": "components", "lvl": 2, "i": 8, "seen": 0 },
+        { "content": "Final Build", "slug": "final-build", "lvl": 2, "i": 9, "seen": 0 },
+        { "content": "Next Section", "slug": "next-section", "lvl": 2, "i": 10, "seen": 0 }
       ]
     },
     "imports": [],
-    "resources": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/884562519.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css"
+    ],
     "pagePath": "./guides/getting-started/walkthrough.md",
     "outputPath": "/guides/getting-started/walkthrough/index.html",
     "isSSR": false,
@@ -781,31 +840,25 @@
       "order": 3,
       "tocHeading": 2,
       "tableOfContents": [
-        {
-          "content": "Static Hosting",
-          "slug": "static-hosting",
-          "lvl": 2,
-          "i": 1,
-          "seen": 0
-        },
-        {
-          "content": "Serverless",
-          "slug": "serverless",
-          "lvl": 2,
-          "i": 2,
-          "seen": 0
-        },
-        {
-          "content": "GitHub Actions",
-          "slug": "github-actions",
-          "lvl": 2,
-          "i": 3,
-          "seen": 0
-        }
+        { "content": "Static Hosting", "slug": "static-hosting", "lvl": 2, "i": 1, "seen": 0 },
+        { "content": "Serverless", "slug": "serverless", "lvl": 2, "i": 2, "seen": 0 },
+        { "content": "GitHub Actions", "slug": "github-actions", "lvl": 2, "i": 3, "seen": 0 }
       ]
     },
     "imports": [],
-    "resources": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/884562519.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css"
+    ],
     "pagePath": "./guides/hosting/aws.md",
     "outputPath": "/guides/hosting/aws/index.html",
     "isSSR": false,
@@ -823,24 +876,24 @@
       "order": 4,
       "tocHeading": 2,
       "tableOfContents": [
-        {
-          "content": "Pages",
-          "slug": "pages",
-          "lvl": 2,
-          "i": 1,
-          "seen": 0
-        },
-        {
-          "content": "Workers",
-          "slug": "workers",
-          "lvl": 2,
-          "i": 2,
-          "seen": 0
-        }
+        { "content": "Pages", "slug": "pages", "lvl": 2, "i": 1, "seen": 0 },
+        { "content": "Workers", "slug": "workers", "lvl": 2, "i": 2, "seen": 0 }
       ]
     },
     "imports": [],
-    "resources": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/884562519.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css"
+    ],
     "pagePath": "./guides/hosting/cloudflare.md",
     "outputPath": "/guides/hosting/cloudflare/index.html",
     "isSSR": false,
@@ -858,31 +911,25 @@
       "order": 5,
       "tocHeading": 2,
       "tableOfContents": [
-        {
-          "content": "Prerequisites",
-          "slug": "prerequisites",
-          "lvl": 2,
-          "i": 1,
-          "seen": 0
-        },
-        {
-          "content": "Setup",
-          "slug": "setup",
-          "lvl": 2,
-          "i": 2,
-          "seen": 0
-        },
-        {
-          "content": "Next Steps",
-          "slug": "next-steps",
-          "lvl": 2,
-          "i": 3,
-          "seen": 0
-        }
+        { "content": "Prerequisites", "slug": "prerequisites", "lvl": 2, "i": 1, "seen": 0 },
+        { "content": "Setup", "slug": "setup", "lvl": 2, "i": 2, "seen": 0 },
+        { "content": "Next Steps", "slug": "next-steps", "lvl": 2, "i": 3, "seen": 0 }
       ]
     },
     "imports": [],
-    "resources": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/884562519.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css"
+    ],
     "pagePath": "./guides/hosting/github.md",
     "outputPath": "/guides/hosting/github/index.html",
     "isSSR": false,
@@ -900,45 +947,27 @@
       "order": 2,
       "tocHeading": 2,
       "tableOfContents": [
-        {
-          "content": "Building",
-          "slug": "building",
-          "lvl": 2,
-          "i": 0,
-          "seen": 0
-        },
-        {
-          "content": "Static Hosting",
-          "slug": "static-hosting",
-          "lvl": 2,
-          "i": 1,
-          "seen": 0
-        },
-        {
-          "content": "Self Hosting",
-          "slug": "self-hosting",
-          "lvl": 2,
-          "i": 2,
-          "seen": 0
-        },
-        {
-          "content": "Serverless",
-          "slug": "serverless",
-          "lvl": 2,
-          "i": 3,
-          "seen": 0
-        },
-        {
-          "content": "Docker",
-          "slug": "docker",
-          "lvl": 2,
-          "i": 4,
-          "seen": 0
-        }
+        { "content": "Building", "slug": "building", "lvl": 2, "i": 0, "seen": 0 },
+        { "content": "Static Hosting", "slug": "static-hosting", "lvl": 2, "i": 1, "seen": 0 },
+        { "content": "Self Hosting", "slug": "self-hosting", "lvl": 2, "i": 2, "seen": 0 },
+        { "content": "Serverless", "slug": "serverless", "lvl": 2, "i": 3, "seen": 0 },
+        { "content": "Docker", "slug": "docker", "lvl": 2, "i": 4, "seen": 0 }
       ]
     },
     "imports": [],
-    "resources": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/884562519.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css"
+    ],
     "pagePath": "./guides/hosting/index.md",
     "outputPath": "/guides/hosting/index.html",
     "isSSR": false,
@@ -956,24 +985,24 @@
       "order": 1,
       "tocHeading": 2,
       "tableOfContents": [
-        {
-          "content": "Static Hosting",
-          "slug": "static-hosting",
-          "lvl": 2,
-          "i": 1,
-          "seen": 0
-        },
-        {
-          "content": "Serverless",
-          "slug": "serverless",
-          "lvl": 2,
-          "i": 2,
-          "seen": 0
-        }
+        { "content": "Static Hosting", "slug": "static-hosting", "lvl": 2, "i": 1, "seen": 0 },
+        { "content": "Serverless", "slug": "serverless", "lvl": 2, "i": 2, "seen": 0 }
       ]
     },
     "imports": [],
-    "resources": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/884562519.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css"
+    ],
     "pagePath": "./guides/hosting/netlify.md",
     "outputPath": "/guides/hosting/netlify/index.html",
     "isSSR": false,
@@ -991,24 +1020,24 @@
       "order": 2,
       "tocHeading": 2,
       "tableOfContents": [
-        {
-          "content": "Static Hosting",
-          "slug": "static-hosting",
-          "lvl": 2,
-          "i": 1,
-          "seen": 0
-        },
-        {
-          "content": "Serverless",
-          "slug": "serverless",
-          "lvl": 2,
-          "i": 2,
-          "seen": 0
-        }
+        { "content": "Static Hosting", "slug": "static-hosting", "lvl": 2, "i": 1, "seen": 0 },
+        { "content": "Serverless", "slug": "serverless", "lvl": 2, "i": 2, "seen": 0 }
       ]
     },
     "imports": [],
-    "resources": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/884562519.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css"
+    ],
     "pagePath": "./guides/hosting/vercel.md",
     "outputPath": "/guides/hosting/vercel/index.html",
     "isSSR": false,
@@ -1022,12 +1051,21 @@
     "title": "Guides",
     "route": "/guides/",
     "layout": "guides",
-    "data": {
-      "tocHeading": 0,
-      "tableOfContents": []
-    },
+    "data": { "collection": "nav", "order": 2, "tocHeading": 0, "tableOfContents": [] },
     "imports": [],
-    "resources": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/884562519.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css"
+    ],
     "pagePath": "./guides/index.md",
     "outputPath": "/guides/index.html",
     "isSSR": false,
@@ -1045,59 +1083,29 @@
       "order": 1,
       "tocHeading": 2,
       "tableOfContents": [
-        {
-          "content": "Objective",
-          "slug": "objective",
-          "lvl": 2,
-          "i": 1,
-          "seen": 0
-        },
-        {
-          "content": "Card Component",
-          "slug": "card-component",
-          "lvl": 2,
-          "i": 2,
-          "seen": 0
-        },
-        {
-          "content": "Search API",
-          "slug": "search-api",
-          "lvl": 2,
-          "i": 3,
-          "seen": 0
-        },
-        {
-          "content": "Search Page",
-          "slug": "search-page",
-          "lvl": 2,
-          "i": 4,
-          "seen": 0
-        },
-        {
-          "content": "Products Page",
-          "slug": "products-page",
-          "lvl": 2,
-          "i": 5,
-          "seen": 0
-        },
-        {
-          "content": "App Layout",
-          "slug": "app-layout",
-          "lvl": 2,
-          "i": 6,
-          "seen": 0
-        },
-        {
-          "content": "Conclusion",
-          "slug": "conclusion",
-          "lvl": 2,
-          "i": 7,
-          "seen": 0
-        }
+        { "content": "Objective", "slug": "objective", "lvl": 2, "i": 1, "seen": 0 },
+        { "content": "Card Component", "slug": "card-component", "lvl": 2, "i": 2, "seen": 0 },
+        { "content": "Search API", "slug": "search-api", "lvl": 2, "i": 3, "seen": 0 },
+        { "content": "Search Page", "slug": "search-page", "lvl": 2, "i": 4, "seen": 0 },
+        { "content": "Products Page", "slug": "products-page", "lvl": 2, "i": 5, "seen": 0 },
+        { "content": "App Layout", "slug": "app-layout", "lvl": 2, "i": 6, "seen": 0 },
+        { "content": "Conclusion", "slug": "conclusion", "lvl": 2, "i": 7, "seen": 0 }
       ]
     },
     "imports": [],
-    "resources": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/884562519.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css"
+    ],
     "pagePath": "./guides/tutorials/full-stack-web-components.md",
     "outputPath": "/guides/tutorials/full-stack-web-components/index.html",
     "isSSR": false,
@@ -1111,13 +1119,21 @@
     "title": null,
     "route": "/guides/tutorials/",
     "layout": "guides",
-    "data": {
-      "order": 4,
-      "tocHeading": 0,
-      "tableOfContents": []
-    },
+    "data": { "order": 4, "tocHeading": 0, "tableOfContents": [] },
     "imports": [],
-    "resources": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/884562519.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css"
+    ],
     "pagePath": "./guides/tutorials/index.md",
     "outputPath": "/guides/tutorials/index.html",
     "isSSR": false,
@@ -1135,27 +1151,9 @@
       "order": 2,
       "tocHeading": 2,
       "tableOfContents": [
-        {
-          "content": "Prerequisites",
-          "slug": "prerequisites",
-          "lvl": 2,
-          "i": 1,
-          "seen": 0
-        },
-        {
-          "content": "Project Setup",
-          "slug": "project-setup",
-          "lvl": 2,
-          "i": 2,
-          "seen": 0
-        },
-        {
-          "content": "Development",
-          "slug": "development",
-          "lvl": 2,
-          "i": 3,
-          "seen": 0
-        },
+        { "content": "Prerequisites", "slug": "prerequisites", "lvl": 2, "i": 1, "seen": 0 },
+        { "content": "Project Setup", "slug": "project-setup", "lvl": 2, "i": 2, "seen": 0 },
+        { "content": "Development", "slug": "development", "lvl": 2, "i": 3, "seen": 0 },
         {
           "content": "Production Testing",
           "slug": "production-testing",
@@ -1163,13 +1161,7 @@
           "i": 4,
           "seen": 0
         },
-        {
-          "content": "Publishing",
-          "slug": "publishing",
-          "lvl": 2,
-          "i": 5,
-          "seen": 0
-        },
+        { "content": "Publishing", "slug": "publishing", "lvl": 2, "i": 5, "seen": 0 },
         {
           "content": "Installation and Usage for Users",
           "slug": "installation-and-usage-for-users",
@@ -1177,17 +1169,23 @@
           "i": 6,
           "seen": 0
         },
-        {
-          "content": "FAQ",
-          "slug": "faq",
-          "lvl": 2,
-          "i": 7,
-          "seen": 0
-        }
+        { "content": "FAQ", "slug": "faq", "lvl": 2, "i": 7, "seen": 0 }
       ]
     },
     "imports": [],
-    "resources": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/884562519.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css"
+    ],
     "pagePath": "./guides/tutorials/theme-packs.md",
     "outputPath": "/guides/tutorials/theme-packs/index.html",
     "isSSR": false,
@@ -1201,10 +1199,7 @@
     "title": null,
     "route": "/",
     "layout": "page",
-    "data": {
-      "tocHeading": 0,
-      "tableOfContents": []
-    },
+    "data": { "tocHeading": 0, "tableOfContents": [] },
     "imports": [
       "../components/latest-post/latest-post.js data-gwd-opt=\"static\" type=\"module\"",
       "../components/hero-banner/hero-banner.js data-gwd-opt=\"static\" type=\"module\"",
@@ -1213,10 +1208,24 @@
       "../components/run-anywhere/run-anywhere.js data-gwd-opt=\"static\" type=\"module\"",
       "../components/build-with-friends/build-with-friends.js data-gwd-opt=\"static\" type=\"module\"",
       "../components/get-started/get-started.js data-gwd-opt=\"static\" type=\"module\"",
-      "../components/edit-on-github/edit-on-github.js data-gwd-opt=\"static\" type=\"module\"",
       "../styles/home.css"
     ],
-    "resources": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/latest-post/latest-post.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/hero-banner/hero-banner.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/capabilities/capabilities.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/why-greenwood/why-greenwood.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/run-anywhere/run-anywhere.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/build-with-friends/build-with-friends.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/get-started/get-started.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/home.css"
+    ],
     "pagePath": "./index.md",
     "outputPath": "/index.html",
     "isSSR": false,
@@ -1233,7 +1242,15 @@
     "title": "Page Not Found",
     "data": {},
     "imports": [],
-    "resources": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1107222808.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css"
+    ],
     "prerender": true,
     "isolation": false,
     "path": "404.html"

--- a/src/stories/mocks/graph.json
+++ b/src/stories/mocks/graph.json
@@ -1,23 +1,25 @@
 [
   {
+    "id": "blog-index",
     "label": "Blog",
-    "title": null,
+    "title": "Blog",
     "route": "/blog/",
     "layout": null,
     "data": { "collection": "nav", "order": 3, "tocHeading": 0, "tableOfContents": [] },
     "imports": [],
     "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/blog-posts-list/blog-posts-list.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1494238925.css",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css"
     ],
-    "pagePath": "./blog/index.html",
-    "outputPath": "/blog/index.html",
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/blog/index.html",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/blog/index.html",
     "isSSR": false,
     "prerender": true,
     "isolation": false,
@@ -25,6 +27,7 @@
     "servePage": null
   },
   {
+    "id": "blog-release-v0-15-0",
     "label": "V0 15 0",
     "title": "Release - v0.15.0",
     "route": "/blog/release/v0-15-0/",
@@ -37,16 +40,17 @@
     },
     "imports": [],
     "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/blog.css"
     ],
-    "pagePath": "./blog/release/v0-15-0.md",
-    "outputPath": "/blog/release/v0-15-0/index.html",
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/blog/release/v0-15-0.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/blog/release/v0-15-0/index.html",
     "isSSR": false,
     "prerender": true,
     "isolation": false,
@@ -54,6 +58,7 @@
     "servePage": null
   },
   {
+    "id": "blog-release-v0-18-0",
     "label": "V0 18 0",
     "title": "Release - v0.18.0",
     "route": "/blog/release/v0-18-0/",
@@ -66,16 +71,17 @@
     },
     "imports": [],
     "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/blog.css"
     ],
-    "pagePath": "./blog/release/v0-18-0.md",
-    "outputPath": "/blog/release/v0-18-0/index.html",
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/blog/release/v0-18-0.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/blog/release/v0-18-0/index.html",
     "isSSR": false,
     "prerender": true,
     "isolation": false,
@@ -83,6 +89,7 @@
     "servePage": null
   },
   {
+    "id": "blog-release-v0-19-0",
     "label": "V0 19 0",
     "title": "Release -  v0.19.0",
     "route": "/blog/release/v0-19-0/",
@@ -95,16 +102,17 @@
     },
     "imports": [],
     "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/blog.css"
     ],
-    "pagePath": "./blog/release/v0-19-0.md",
-    "outputPath": "/blog/release/v0-19-0/index.html",
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/blog/release/v0-19-0.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/blog/release/v0-19-0/index.html",
     "isSSR": false,
     "prerender": true,
     "isolation": false,
@@ -112,6 +120,7 @@
     "servePage": null
   },
   {
+    "id": "blog-release-v0-20-0",
     "label": "V0 20 0",
     "title": "Release - v0.20.0",
     "route": "/blog/release/v0-20-0/",
@@ -125,16 +134,17 @@
     },
     "imports": [],
     "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/blog.css"
     ],
-    "pagePath": "./blog/release/v0-20-0.md",
-    "outputPath": "/blog/release/v0-20-0/index.html",
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/blog/release/v0-20-0.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/blog/release/v0-20-0/index.html",
     "isSSR": false,
     "prerender": true,
     "isolation": false,
@@ -142,6 +152,7 @@
     "servePage": null
   },
   {
+    "id": "blog-release-v0-21-0",
     "label": "V0 21 0",
     "title": "Release - v0.21.0",
     "route": "/blog/release/v0-21-0/",
@@ -154,16 +165,17 @@
     },
     "imports": [],
     "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/blog.css"
     ],
-    "pagePath": "./blog/release/v0-21-0.md",
-    "outputPath": "/blog/release/v0-21-0/index.html",
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/blog/release/v0-21-0.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/blog/release/v0-21-0/index.html",
     "isSSR": false,
     "prerender": true,
     "isolation": false,
@@ -171,6 +183,7 @@
     "servePage": null
   },
   {
+    "id": "blog-release-v0-23-0",
     "label": "V0 23 0",
     "title": "Release - v0.23.0",
     "route": "/blog/release/v0-23-0/",
@@ -183,16 +196,17 @@
     },
     "imports": [],
     "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/blog.css"
     ],
-    "pagePath": "./blog/release/v0-23-0.md",
-    "outputPath": "/blog/release/v0-23-0/index.html",
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/blog/release/v0-23-0.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/blog/release/v0-23-0/index.html",
     "isSSR": false,
     "prerender": true,
     "isolation": false,
@@ -200,6 +214,7 @@
     "servePage": null
   },
   {
+    "id": "blog-release-v0-24-0",
     "label": "V0 24 0",
     "title": "Release - v0.24.0",
     "route": "/blog/release/v0-24-0/",
@@ -212,16 +227,17 @@
     },
     "imports": [],
     "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/blog.css"
     ],
-    "pagePath": "./blog/release/v0-24-0.md",
-    "outputPath": "/blog/release/v0-24-0/index.html",
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/blog/release/v0-24-0.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/blog/release/v0-24-0/index.html",
     "isSSR": false,
     "prerender": true,
     "isolation": false,
@@ -229,6 +245,7 @@
     "servePage": null
   },
   {
+    "id": "blog-release-v0-26-0",
     "label": "V0 26 0",
     "title": "Release -  v0.26.0",
     "route": "/blog/release/v0-26-0/",
@@ -242,17 +259,18 @@
     },
     "imports": [],
     "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/339602163.css",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/blog.css"
     ],
-    "pagePath": "./blog/release/v0-26-0.md",
-    "outputPath": "/blog/release/v0-26-0/index.html",
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/blog/release/v0-26-0.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/blog/release/v0-26-0/index.html",
     "isSSR": false,
     "prerender": true,
     "isolation": false,
@@ -260,6 +278,7 @@
     "servePage": null
   },
   {
+    "id": "blog-release-v0-27-0",
     "label": "V0 27 0",
     "title": "Release - v0.27.0",
     "route": "/blog/release/v0-27-0/",
@@ -273,17 +292,18 @@
     },
     "imports": [],
     "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/865966005.css",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/blog.css"
     ],
-    "pagePath": "./blog/release/v0-27-0.md",
-    "outputPath": "/blog/release/v0-27-0/index.html",
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/blog/release/v0-27-0.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/blog/release/v0-27-0/index.html",
     "isSSR": false,
     "prerender": true,
     "isolation": false,
@@ -291,6 +311,7 @@
     "servePage": null
   },
   {
+    "id": "blog-release-v0-28-0",
     "label": "V0 28 0",
     "title": "Release - v0.28.0",
     "route": "/blog/release/v0-28-0/",
@@ -304,16 +325,17 @@
     },
     "imports": [],
     "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/blog.css"
     ],
-    "pagePath": "./blog/release/v0-28-0.md",
-    "outputPath": "/blog/release/v0-28-0/index.html",
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/blog/release/v0-28-0.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/blog/release/v0-28-0/index.html",
     "isSSR": false,
     "prerender": true,
     "isolation": false,
@@ -321,6 +343,7 @@
     "servePage": null
   },
   {
+    "id": "blog-release-v0-29-0",
     "label": "V0 29 0",
     "title": "Release - v0.29.0",
     "route": "/blog/release/v0-29-0/",
@@ -334,16 +357,17 @@
     },
     "imports": [],
     "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/blog.css"
     ],
-    "pagePath": "./blog/release/v0-29-0.md",
-    "outputPath": "/blog/release/v0-29-0/index.html",
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/blog/release/v0-29-0.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/blog/release/v0-29-0/index.html",
     "isSSR": false,
     "prerender": true,
     "isolation": false,
@@ -351,6 +375,7 @@
     "servePage": null
   },
   {
+    "id": "blog-state-of-greenwood-2022",
     "label": "State Of Greenwood 2022",
     "title": "State of Greenwood (2022)",
     "route": "/blog/state-of-greenwood-2022/",
@@ -364,16 +389,17 @@
     },
     "imports": [],
     "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/blog.css"
     ],
-    "pagePath": "./blog/state-of-greenwood-2022.md",
-    "outputPath": "/blog/state-of-greenwood-2022/index.html",
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/blog/state-of-greenwood-2022.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/blog/state-of-greenwood-2022/index.html",
     "isSSR": false,
     "prerender": true,
     "isolation": false,
@@ -381,6 +407,7 @@
     "servePage": null
   },
   {
+    "id": "blog-state-of-greenwood-2023",
     "label": "State Of Greenwood 2023",
     "title": "State of Greenwood (2023)",
     "route": "/blog/state-of-greenwood-2023/",
@@ -394,16 +421,17 @@
     },
     "imports": [],
     "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/blog.css"
     ],
-    "pagePath": "./blog/state-of-greenwood-2023.md",
-    "outputPath": "/blog/state-of-greenwood-2023/index.html",
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/blog/state-of-greenwood-2023.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/blog/state-of-greenwood-2023/index.html",
     "isSSR": false,
     "prerender": true,
     "isolation": false,
@@ -411,6 +439,1231 @@
     "servePage": null
   },
   {
+    "id": "docs-content-as-data-active-frontmatter",
+    "label": "Active Frontmatter",
+    "title": null,
+    "route": "/docs/content-as-data/active-frontmatter/",
+    "layout": "docs",
+    "data": {
+      "order": 4,
+      "tocHeading": 2,
+      "tableOfContents": [
+        { "content": "Usage", "slug": "usage", "lvl": 2, "i": 1, "seen": 0 },
+        { "content": "Data Client", "slug": "data-client", "lvl": 2, "i": 2, "seen": 0 }
+      ]
+    },
+    "imports": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
+    ],
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/docs/content-as-data/active-frontmatter.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/docs/content-as-data/active-frontmatter/index.html",
+    "isSSR": false,
+    "prerender": true,
+    "isolation": false,
+    "hydration": false,
+    "servePage": null
+  },
+  {
+    "id": "docs-content-as-data-collections",
+    "label": "Collections",
+    "title": null,
+    "route": "/docs/content-as-data/collections/",
+    "layout": "docs",
+    "data": {
+      "order": 3,
+      "tocHeading": 2,
+      "tableOfContents": [{ "content": "Usage", "slug": "usage", "lvl": 2, "i": 1, "seen": 0 }]
+    },
+    "imports": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
+    ],
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/docs/content-as-data/collections.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/docs/content-as-data/collections/index.html",
+    "isSSR": false,
+    "prerender": true,
+    "isolation": false,
+    "hydration": false,
+    "servePage": null
+  },
+  {
+    "id": "docs-content-as-data-data-client",
+    "label": "Data Client",
+    "title": null,
+    "route": "/docs/content-as-data/data-client/",
+    "layout": "docs",
+    "data": {
+      "order": 2,
+      "tocHeading": 2,
+      "tableOfContents": [
+        { "content": "Content", "slug": "content", "lvl": 2, "i": 1, "seen": 0 },
+        { "content": "Content By Route", "slug": "content-by-route", "lvl": 2, "i": 2, "seen": 0 },
+        {
+          "content": "Content By Collection",
+          "slug": "content-by-collection",
+          "lvl": 2,
+          "i": 3,
+          "seen": 0
+        },
+        { "content": "Integrations", "slug": "integrations", "lvl": 2, "i": 4, "seen": 0 }
+      ]
+    },
+    "imports": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
+    ],
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/docs/content-as-data/data-client.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/docs/content-as-data/data-client/index.html",
+    "isSSR": false,
+    "prerender": true,
+    "isolation": false,
+    "hydration": false,
+    "servePage": null
+  },
+  {
+    "id": "docs-content-as-data-graph-ql",
+    "label": "GraphQL",
+    "title": "GraphQL",
+    "route": "/docs/content-as-data/graph-ql/",
+    "layout": "docs",
+    "data": { "order": 5, "tocHeading": 2, "tableOfContents": [] },
+    "imports": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
+    ],
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/docs/content-as-data/graph-ql.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/docs/content-as-data/graph-ql/index.html",
+    "isSSR": false,
+    "prerender": true,
+    "isolation": false,
+    "hydration": false,
+    "servePage": null
+  },
+  {
+    "id": "docs-content-as-data-index",
+    "label": "Content As Data",
+    "title": null,
+    "route": "/docs/content-as-data/",
+    "layout": "docs",
+    "data": { "order": 5, "tocHeading": 0, "tableOfContents": [] },
+    "imports": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
+    ],
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/docs/content-as-data/index.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/docs/content-as-data/index.html",
+    "isSSR": false,
+    "prerender": true,
+    "isolation": false,
+    "hydration": false,
+    "servePage": null
+  },
+  {
+    "id": "docs-content-as-data-pages-data",
+    "label": "Pages Data",
+    "title": null,
+    "route": "/docs/content-as-data/pages-data/",
+    "layout": "docs",
+    "data": {
+      "order": 1,
+      "tocHeading": 2,
+      "tableOfContents": [
+        { "content": "Schema", "slug": "schema", "lvl": 2, "i": 1, "seen": 0 },
+        {
+          "content": "Table of Contents",
+          "slug": "table-of-contents",
+          "lvl": 2,
+          "i": 2,
+          "seen": 0
+        },
+        { "content": "External Content", "slug": "external-content", "lvl": 2, "i": 3, "seen": 0 }
+      ]
+    },
+    "imports": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
+    ],
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/docs/content-as-data/pages-data.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/docs/content-as-data/pages-data/index.html",
+    "isSSR": false,
+    "prerender": true,
+    "isolation": false,
+    "hydration": false,
+    "servePage": null
+  },
+  {
+    "id": "docs-index",
+    "label": "Docs",
+    "title": "Docs",
+    "route": "/docs/",
+    "layout": "docs",
+    "data": { "collection": "nav", "order": 1, "tocHeading": 0, "tableOfContents": [] },
+    "imports": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
+    ],
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/docs/index.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/docs/index.html",
+    "isSSR": false,
+    "prerender": true,
+    "isolation": false,
+    "hydration": false,
+    "servePage": null
+  },
+  {
+    "id": "docs-introduction-about",
+    "label": "About",
+    "title": null,
+    "route": "/docs/introduction/about/",
+    "layout": "docs",
+    "data": {
+      "order": 1,
+      "tocHeading": 2,
+      "tableOfContents": [
+        { "content": "Features", "slug": "features", "lvl": 2, "i": 1, "seen": 0 },
+        { "content": "Goals", "slug": "goals", "lvl": 2, "i": 2, "seen": 0 },
+        { "content": "Roadmap", "slug": "roadmap", "lvl": 2, "i": 3, "seen": 0 }
+      ]
+    },
+    "imports": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
+    ],
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/docs/introduction/about.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/docs/introduction/about/index.html",
+    "isSSR": false,
+    "prerender": true,
+    "isolation": false,
+    "hydration": false,
+    "servePage": null
+  },
+  {
+    "id": "docs-introduction-index",
+    "label": "Introduction",
+    "title": null,
+    "route": "/docs/introduction/",
+    "layout": "docs",
+    "data": { "order": 1, "tocHeading": 0, "tableOfContents": [] },
+    "imports": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
+    ],
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/docs/introduction/index.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/docs/introduction/index.html",
+    "isSSR": false,
+    "prerender": true,
+    "isolation": false,
+    "hydration": false,
+    "servePage": null
+  },
+  {
+    "id": "docs-introduction-setup",
+    "label": "Setup",
+    "title": null,
+    "route": "/docs/introduction/setup/",
+    "layout": "docs",
+    "data": {
+      "order": 2,
+      "tocHeading": 2,
+      "tableOfContents": [
+        { "content": "Init", "slug": "init", "lvl": 2, "i": 1, "seen": 0 },
+        { "content": "Install", "slug": "install", "lvl": 2, "i": 2, "seen": 0 },
+        { "content": "Commands", "slug": "commands", "lvl": 2, "i": 3, "seen": 0 }
+      ]
+    },
+    "imports": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
+    ],
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/docs/introduction/setup.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/docs/introduction/setup/index.html",
+    "isSSR": false,
+    "prerender": true,
+    "isolation": false,
+    "hydration": false,
+    "servePage": null
+  },
+  {
+    "id": "docs-introduction-web-standards",
+    "label": "Web Standards",
+    "title": null,
+    "route": "/docs/introduction/web-standards/",
+    "layout": "docs",
+    "data": {
+      "order": 3,
+      "tocHeading": 2,
+      "tableOfContents": [
+        {
+          "content": "Import Attributes",
+          "slug": "import-attributes",
+          "lvl": 2,
+          "i": 1,
+          "seen": 0
+        },
+        { "content": "Web Components", "slug": "web-components", "lvl": 2, "i": 2, "seen": 0 },
+        {
+          "content": "Fetch (and Friends)",
+          "slug": "fetch-and-friends",
+          "lvl": 2,
+          "i": 3,
+          "seen": 0
+        },
+        { "content": "Import Maps", "slug": "import-maps", "lvl": 2, "i": 4, "seen": 0 },
+        { "content": "URL", "slug": "url", "lvl": 2, "i": 5, "seen": 0 },
+        { "content": "FormData", "slug": "formdata", "lvl": 2, "i": 6, "seen": 0 }
+      ]
+    },
+    "imports": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
+    ],
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/docs/introduction/web-standards.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/docs/introduction/web-standards/index.html",
+    "isSSR": false,
+    "prerender": true,
+    "isolation": false,
+    "hydration": false,
+    "servePage": null
+  },
+  {
+    "id": "docs-pages-api-routes",
+    "label": "API Routes",
+    "title": "API Routes",
+    "route": "/docs/pages/api-routes/",
+    "layout": "docs",
+    "data": {
+      "order": 3,
+      "tocHeading": 2,
+      "tableOfContents": [
+        { "content": "Usage", "slug": "usage", "lvl": 2, "i": 1, "seen": 0 },
+        { "content": "Hypermedia", "slug": "hypermedia", "lvl": 2, "i": 2, "seen": 0 },
+        { "content": "Isolation Mode", "slug": "isolation-mode", "lvl": 2, "i": 3, "seen": 0 }
+      ]
+    },
+    "imports": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
+    ],
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/docs/pages/api-routes.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/docs/pages/api-routes/index.html",
+    "isSSR": false,
+    "prerender": true,
+    "isolation": false,
+    "hydration": false,
+    "servePage": null
+  },
+  {
+    "id": "docs-pages-index",
+    "label": "Pages",
+    "title": null,
+    "route": "/docs/pages/",
+    "layout": "docs",
+    "data": { "order": 2, "tocHeading": 0, "tableOfContents": [] },
+    "imports": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
+    ],
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/docs/pages/index.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/docs/pages/index.html",
+    "isSSR": false,
+    "prerender": true,
+    "isolation": false,
+    "hydration": false,
+    "servePage": null
+  },
+  {
+    "id": "docs-pages-layouts",
+    "label": "Layouts",
+    "title": null,
+    "route": "/docs/pages/layouts/",
+    "layout": "docs",
+    "data": {
+      "order": 4,
+      "tocHeading": 2,
+      "tableOfContents": [
+        { "content": "Usage", "slug": "usage", "lvl": 2, "i": 1, "seen": 0 },
+        { "content": "Pages", "slug": "pages", "lvl": 2, "i": 2, "seen": 0 },
+        { "content": "App", "slug": "app", "lvl": 2, "i": 3, "seen": 0 }
+      ]
+    },
+    "imports": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
+    ],
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/docs/pages/layouts.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/docs/pages/layouts/index.html",
+    "isSSR": false,
+    "prerender": true,
+    "isolation": false,
+    "hydration": false,
+    "servePage": null
+  },
+  {
+    "id": "docs-pages-routing",
+    "label": "Routing",
+    "title": null,
+    "route": "/docs/pages/routing/",
+    "layout": "docs",
+    "data": {
+      "order": 1,
+      "tocHeading": 2,
+      "tableOfContents": [
+        { "content": "Static Pages", "slug": "static-pages", "lvl": 2, "i": 1, "seen": 0 },
+        { "content": "SSR", "slug": "ssr", "lvl": 2, "i": 2, "seen": 0 },
+        { "content": "APIs", "slug": "apis", "lvl": 2, "i": 3, "seen": 0 },
+        { "content": "SPA", "slug": "spa", "lvl": 2, "i": 4, "seen": 0 },
+        { "content": "Not Found", "slug": "not-found", "lvl": 2, "i": 5, "seen": 0 }
+      ]
+    },
+    "imports": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
+    ],
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/docs/pages/routing.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/docs/pages/routing/index.html",
+    "isSSR": false,
+    "prerender": true,
+    "isolation": false,
+    "hydration": false,
+    "servePage": null
+  },
+  {
+    "id": "docs-pages-server-rendering",
+    "label": "Server Rendering",
+    "title": null,
+    "route": "/docs/pages/server-rendering/",
+    "layout": "docs",
+    "data": {
+      "order": 2,
+      "tocHeading": 2,
+      "tableOfContents": [
+        { "content": "Usage", "slug": "usage", "lvl": 2, "i": 1, "seen": 0 },
+        { "content": "API", "slug": "api", "lvl": 2, "i": 2, "seen": 0 },
+        { "content": "Options", "slug": "options", "lvl": 2, "i": 7, "seen": 0 },
+        { "content": "Request Data", "slug": "request-data", "lvl": 2, "i": 10, "seen": 0 },
+        { "content": "Custom Imports", "slug": "custom-imports", "lvl": 2, "i": 11, "seen": 0 }
+      ]
+    },
+    "imports": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
+    ],
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/docs/pages/server-rendering.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/docs/pages/server-rendering/index.html",
+    "isSSR": false,
+    "prerender": true,
+    "isolation": false,
+    "hydration": false,
+    "servePage": null
+  },
+  {
+    "id": "docs-plugins-css-modules",
+    "label": "CSS Modules",
+    "title": "CSS Modules",
+    "route": "/docs/plugins/css-modules/",
+    "layout": "docs",
+    "data": {
+      "order": 3,
+      "tocHeading": 2,
+      "tableOfContents": [
+        { "content": "Installation", "slug": "installation", "lvl": 2, "i": 1, "seen": 0 },
+        { "content": "Usage", "slug": "usage", "lvl": 2, "i": 2, "seen": 0 }
+      ]
+    },
+    "imports": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
+    ],
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/docs/plugins/css-modules.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/docs/plugins/css-modules/index.html",
+    "isSSR": false,
+    "prerender": true,
+    "isolation": false,
+    "hydration": false,
+    "servePage": null
+  },
+  {
+    "id": "docs-plugins-index",
+    "label": "Plugins",
+    "title": null,
+    "route": "/docs/plugins/",
+    "layout": "docs",
+    "data": { "order": 4, "tocHeading": 0, "tableOfContents": [] },
+    "imports": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
+    ],
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/docs/plugins/index.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/docs/plugins/index.html",
+    "isSSR": false,
+    "prerender": true,
+    "isolation": false,
+    "hydration": false,
+    "servePage": null
+  },
+  {
+    "id": "docs-plugins-lit-ssr",
+    "label": "Lit SSR",
+    "title": "Lit SSR",
+    "route": "/docs/plugins/lit-ssr/",
+    "layout": "docs",
+    "data": {
+      "order": 2,
+      "tocHeading": 2,
+      "tableOfContents": [
+        { "content": "Prerequisite", "slug": "prerequisite", "lvl": 2, "i": 1, "seen": 0 },
+        { "content": "Installation", "slug": "installation", "lvl": 2, "i": 2, "seen": 0 },
+        { "content": "Usage", "slug": "usage", "lvl": 2, "i": 3, "seen": 0 }
+      ]
+    },
+    "imports": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
+    ],
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/docs/plugins/lit-ssr.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/docs/plugins/lit-ssr/index.html",
+    "isSSR": false,
+    "prerender": true,
+    "isolation": false,
+    "hydration": false,
+    "servePage": null
+  },
+  {
+    "id": "docs-plugins-postcss",
+    "label": "PostCSS",
+    "title": "PostCSS",
+    "route": "/docs/plugins/postcss/",
+    "layout": "docs",
+    "data": {
+      "order": 5,
+      "tocHeading": 2,
+      "tableOfContents": [
+        { "content": "Installation", "slug": "installation", "lvl": 2, "i": 1, "seen": 0 },
+        { "content": "Usage", "slug": "usage", "lvl": 2, "i": 2, "seen": 0 }
+      ]
+    },
+    "imports": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
+    ],
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/docs/plugins/postcss.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/docs/plugins/postcss/index.html",
+    "isSSR": false,
+    "prerender": true,
+    "isolation": false,
+    "hydration": false,
+    "servePage": null
+  },
+  {
+    "id": "docs-plugins-raw",
+    "label": "Raw",
+    "title": null,
+    "route": "/docs/plugins/raw/",
+    "layout": "docs",
+    "data": {
+      "order": 4,
+      "tocHeading": 2,
+      "tableOfContents": [
+        { "content": "Installation", "slug": "installation", "lvl": 2, "i": 1, "seen": 0 },
+        { "content": "Usage", "slug": "usage", "lvl": 2, "i": 2, "seen": 0 }
+      ]
+    },
+    "imports": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
+    ],
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/docs/plugins/raw.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/docs/plugins/raw/index.html",
+    "isSSR": false,
+    "prerender": true,
+    "isolation": false,
+    "hydration": false,
+    "servePage": null
+  },
+  {
+    "id": "docs-plugins-typescript",
+    "label": "TypeScript",
+    "title": "TypeScript",
+    "route": "/docs/plugins/typescript/",
+    "layout": "docs",
+    "data": {
+      "order": 1,
+      "tocHeading": 2,
+      "tableOfContents": [
+        { "content": "Installation", "slug": "installation", "lvl": 2, "i": 1, "seen": 0 },
+        { "content": "Usage", "slug": "usage", "lvl": 2, "i": 2, "seen": 0 }
+      ]
+    },
+    "imports": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
+    ],
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/docs/plugins/typescript.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/docs/plugins/typescript/index.html",
+    "isSSR": false,
+    "prerender": true,
+    "isolation": false,
+    "hydration": false,
+    "servePage": null
+  },
+  {
+    "id": "docs-reference-appendix",
+    "label": "Appendix",
+    "title": null,
+    "route": "/docs/reference/appendix/",
+    "layout": "docs",
+    "data": {
+      "order": 5,
+      "tocHeading": 2,
+      "tableOfContents": [
+        { "content": "Build Output", "slug": "build-output", "lvl": 2, "i": 1, "seen": 0 },
+        { "content": "Compilation", "slug": "compilation", "lvl": 2, "i": 2, "seen": 0 },
+        { "content": "DOM Emulation", "slug": "dom-emulation", "lvl": 2, "i": 6, "seen": 0 },
+        {
+          "content": "Environment Variables",
+          "slug": "environment-variables",
+          "lvl": 2,
+          "i": 8,
+          "seen": 0
+        }
+      ]
+    },
+    "imports": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
+    ],
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/docs/reference/appendix.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/docs/reference/appendix/index.html",
+    "isSSR": false,
+    "prerender": true,
+    "isolation": false,
+    "hydration": false,
+    "servePage": null
+  },
+  {
+    "id": "docs-reference-configuration",
+    "label": "Configuration",
+    "title": null,
+    "route": "/docs/reference/configuration/",
+    "layout": "docs",
+    "data": {
+      "order": 1,
+      "tocHeading": 2,
+      "tableOfContents": [
+        { "content": "Active Content", "slug": "active-content", "lvl": 2, "i": 1, "seen": 0 },
+        { "content": "Base Path", "slug": "base-path", "lvl": 2, "i": 2, "seen": 0 },
+        { "content": "Dev Server", "slug": "dev-server", "lvl": 2, "i": 3, "seen": 0 },
+        { "content": "Isolation Mode", "slug": "isolation-mode", "lvl": 2, "i": 4, "seen": 0 },
+        {
+          "content": "Layouts Directory",
+          "slug": "layouts-directory",
+          "lvl": 2,
+          "i": 5,
+          "seen": 0
+        },
+        { "content": "Markdown", "slug": "markdown", "lvl": 2, "i": 6, "seen": 0 },
+        { "content": "Optimization", "slug": "optimization", "lvl": 2, "i": 7, "seen": 0 },
+        { "content": "Pages Directory", "slug": "pages-directory", "lvl": 2, "i": 9, "seen": 0 },
+        { "content": "Plugins", "slug": "plugins", "lvl": 2, "i": 10, "seen": 0 },
+        { "content": "Polyfills", "slug": "polyfills", "lvl": 2, "i": 11, "seen": 0 },
+        { "content": "Port", "slug": "port", "lvl": 2, "i": 14, "seen": 0 },
+        { "content": "Prerender", "slug": "prerender", "lvl": 2, "i": 15, "seen": 0 },
+        { "content": "Static Router", "slug": "static-router", "lvl": 2, "i": 16, "seen": 0 },
+        { "content": "Workspace", "slug": "workspace", "lvl": 2, "i": 17, "seen": 0 }
+      ]
+    },
+    "imports": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
+    ],
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/docs/reference/configuration.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/docs/reference/configuration/index.html",
+    "isSSR": false,
+    "prerender": true,
+    "isolation": false,
+    "hydration": false,
+    "servePage": null
+  },
+  {
+    "id": "docs-reference-index",
+    "label": "Reference",
+    "title": null,
+    "route": "/docs/reference/",
+    "layout": "docs",
+    "data": { "order": 6, "tocHeading": 0, "tableOfContents": [] },
+    "imports": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
+    ],
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/docs/reference/index.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/docs/reference/index.html",
+    "isSSR": false,
+    "prerender": true,
+    "isolation": false,
+    "hydration": false,
+    "servePage": null
+  },
+  {
+    "id": "docs-reference-plugins-api",
+    "label": "Plugins API",
+    "title": "Plugins API",
+    "route": "/docs/reference/plugins-api/",
+    "layout": "docs",
+    "data": {
+      "order": 2,
+      "tocHeading": 2,
+      "tableOfContents": [
+        { "content": "Overview", "slug": "overview", "lvl": 2, "i": 1, "seen": 0 },
+        { "content": "Adapter", "slug": "adapter", "lvl": 2, "i": 2, "seen": 0 },
+        { "content": "Context", "slug": "context", "lvl": 2, "i": 5, "seen": 0 },
+        { "content": "Copy", "slug": "copy", "lvl": 2, "i": 8, "seen": 0 },
+        { "content": "Renderer", "slug": "renderer", "lvl": 2, "i": 10, "seen": 0 },
+        { "content": "Resource", "slug": "resource", "lvl": 2, "i": 16, "seen": 0 },
+        { "content": "Rollup", "slug": "rollup", "lvl": 2, "i": 24, "seen": 0 },
+        { "content": "Server", "slug": "server", "lvl": 2, "i": 25, "seen": 0 },
+        { "content": "Source", "slug": "source", "lvl": 2, "i": 28, "seen": 0 }
+      ]
+    },
+    "imports": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
+    ],
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/docs/reference/plugins-api.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/docs/reference/plugins-api/index.html",
+    "isSSR": false,
+    "prerender": true,
+    "isolation": false,
+    "hydration": false,
+    "servePage": null
+  },
+  {
+    "id": "docs-reference-rendering-strategies",
+    "label": "Rendering Strategies",
+    "title": null,
+    "route": "/docs/reference/rendering-strategies/",
+    "layout": "docs",
+    "data": {
+      "order": 3,
+      "tocHeading": 2,
+      "tableOfContents": [
+        { "content": "CSR", "slug": "csr", "lvl": 2, "i": 1, "seen": 0 },
+        { "content": "SSG", "slug": "ssg", "lvl": 2, "i": 2, "seen": 0 },
+        { "content": "SSR", "slug": "ssr", "lvl": 2, "i": 3, "seen": 0 },
+        { "content": "Prerendering", "slug": "prerendering", "lvl": 2, "i": 4, "seen": 0 }
+      ]
+    },
+    "imports": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
+    ],
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/docs/reference/rendering-strategies.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/docs/reference/rendering-strategies/index.html",
+    "isSSR": false,
+    "prerender": true,
+    "isolation": false,
+    "hydration": false,
+    "servePage": null
+  },
+  {
+    "id": "docs-resources-assets",
+    "label": "Assets",
+    "title": null,
+    "route": "/docs/resources/assets/",
+    "layout": "docs",
+    "data": {
+      "order": 3,
+      "tocHeading": 2,
+      "tableOfContents": [
+        { "content": "Directory", "slug": "directory", "lvl": 2, "i": 1, "seen": 0 },
+        { "content": "URL", "slug": "url", "lvl": 2, "i": 2, "seen": 0 },
+        { "content": "Meta Files", "slug": "meta-files", "lvl": 2, "i": 3, "seen": 0 }
+      ]
+    },
+    "imports": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
+    ],
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/docs/resources/assets.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/docs/resources/assets/index.html",
+    "isSSR": false,
+    "prerender": true,
+    "isolation": false,
+    "hydration": false,
+    "servePage": null
+  },
+  {
+    "id": "docs-resources-index",
+    "label": "Resources",
+    "title": null,
+    "route": "/docs/resources/",
+    "layout": "docs",
+    "data": { "order": 3, "tocHeading": 0, "tableOfContents": [] },
+    "imports": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
+    ],
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/docs/resources/index.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/docs/resources/index.html",
+    "isSSR": false,
+    "prerender": true,
+    "isolation": false,
+    "hydration": false,
+    "servePage": null
+  },
+  {
+    "id": "docs-resources-markdown",
+    "label": "Markdown",
+    "title": null,
+    "route": "/docs/resources/markdown/",
+    "layout": "docs",
+    "data": {
+      "order": 4,
+      "tocHeading": 2,
+      "tableOfContents": [
+        { "content": "Plugins", "slug": "plugins", "lvl": 2, "i": 1, "seen": 0 },
+        {
+          "content": "Syntax Highlighting",
+          "slug": "syntax-highlighting",
+          "lvl": 2,
+          "i": 2,
+          "seen": 0
+        },
+        { "content": "Frontmatter", "slug": "frontmatter", "lvl": 2, "i": 3, "seen": 0 },
+        {
+          "content": "Active Frontmatter",
+          "slug": "active-frontmatter",
+          "lvl": 2,
+          "i": 9,
+          "seen": 0
+        }
+      ]
+    },
+    "imports": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
+    ],
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/docs/resources/markdown.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/docs/resources/markdown/index.html",
+    "isSSR": false,
+    "prerender": true,
+    "isolation": false,
+    "hydration": false,
+    "servePage": null
+  },
+  {
+    "id": "docs-resources-scripts",
+    "label": "Scripts",
+    "title": null,
+    "route": "/docs/resources/scripts/",
+    "layout": "docs",
+    "data": {
+      "order": 1,
+      "tocHeading": 2,
+      "tableOfContents": [
+        { "content": "Script Tags", "slug": "script-tags", "lvl": 2, "i": 1, "seen": 0 },
+        { "content": "Modules (ESM)", "slug": "modules-esm", "lvl": 2, "i": 2, "seen": 0 },
+        { "content": "Node Modules", "slug": "node-modules", "lvl": 2, "i": 3, "seen": 0 }
+      ]
+    },
+    "imports": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
+    ],
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/docs/resources/scripts.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/docs/resources/scripts/index.html",
+    "isSSR": false,
+    "prerender": true,
+    "isolation": false,
+    "hydration": false,
+    "servePage": null
+  },
+  {
+    "id": "docs-resources-styles",
+    "label": "Styles",
+    "title": null,
+    "route": "/docs/resources/styles/",
+    "layout": "docs",
+    "data": {
+      "order": 2,
+      "tocHeading": 2,
+      "tableOfContents": [
+        {
+          "content": "Style and Link Tags",
+          "slug": "style-and-link-tags",
+          "lvl": 2,
+          "i": 1,
+          "seen": 0
+        },
+        { "content": "NPM", "slug": "npm", "lvl": 2, "i": 2, "seen": 0 }
+      ]
+    },
+    "imports": [],
+    "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/heading-box/heading-box.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
+    ],
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/docs/resources/styles.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/docs/resources/styles/index.html",
+    "isSSR": false,
+    "prerender": true,
+    "isolation": false,
+    "hydration": false,
+    "servePage": null
+  },
+  {
+    "id": "guides-ecosystem-htmx",
     "label": "htmx",
     "title": "htmx",
     "route": "/guides/ecosystem/htmx/",
@@ -425,6 +1678,7 @@
     },
     "imports": [],
     "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
@@ -433,12 +1687,12 @@
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/884562519.css",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css"
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
     ],
-    "pagePath": "./guides/ecosystem/htmx.md",
-    "outputPath": "/guides/ecosystem/htmx/index.html",
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/guides/ecosystem/htmx.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/guides/ecosystem/htmx/index.html",
     "isSSR": false,
     "prerender": true,
     "isolation": false,
@@ -446,6 +1700,7 @@
     "servePage": null
   },
   {
+    "id": "guides-ecosystem-index",
     "label": "Ecosystem",
     "title": null,
     "route": "/guides/ecosystem/",
@@ -453,6 +1708,7 @@
     "data": { "order": 3, "tocHeading": 0, "tableOfContents": [] },
     "imports": [],
     "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
@@ -461,12 +1717,12 @@
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/884562519.css",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css"
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
     ],
-    "pagePath": "./guides/ecosystem/index.md",
-    "outputPath": "/guides/ecosystem/index.html",
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/guides/ecosystem/index.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/guides/ecosystem/index.html",
     "isSSR": false,
     "prerender": true,
     "isolation": false,
@@ -474,6 +1730,7 @@
     "servePage": null
   },
   {
+    "id": "guides-ecosystem-lit",
     "label": "Lit",
     "title": "Lit",
     "route": "/guides/ecosystem/lit/",
@@ -488,6 +1745,7 @@
     },
     "imports": [],
     "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
@@ -496,12 +1754,12 @@
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/884562519.css",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css"
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
     ],
-    "pagePath": "./guides/ecosystem/lit.md",
-    "outputPath": "/guides/ecosystem/lit/index.html",
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/guides/ecosystem/lit.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/guides/ecosystem/lit/index.html",
     "isSSR": false,
     "prerender": true,
     "isolation": false,
@@ -509,6 +1767,7 @@
     "servePage": null
   },
   {
+    "id": "guides-ecosystem-storybook",
     "label": "Storybook",
     "title": null,
     "route": "/guides/ecosystem/storybook/",
@@ -533,6 +1792,7 @@
     },
     "imports": [],
     "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
@@ -541,12 +1801,12 @@
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/884562519.css",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css"
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
     ],
-    "pagePath": "./guides/ecosystem/storybook.md",
-    "outputPath": "/guides/ecosystem/storybook/index.html",
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/guides/ecosystem/storybook.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/guides/ecosystem/storybook/index.html",
     "isSSR": false,
     "prerender": true,
     "isolation": false,
@@ -554,6 +1814,7 @@
     "servePage": null
   },
   {
+    "id": "guides-ecosystem-tailwind",
     "label": "Tailwind",
     "title": null,
     "route": "/guides/ecosystem/tailwind/",
@@ -568,6 +1829,7 @@
     },
     "imports": [],
     "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
@@ -576,12 +1838,12 @@
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/884562519.css",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css"
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
     ],
-    "pagePath": "./guides/ecosystem/tailwind.md",
-    "outputPath": "/guides/ecosystem/tailwind/index.html",
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/guides/ecosystem/tailwind.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/guides/ecosystem/tailwind/index.html",
     "isSSR": false,
     "prerender": true,
     "isolation": false,
@@ -589,6 +1851,7 @@
     "servePage": null
   },
   {
+    "id": "guides-ecosystem-web-test-runner",
     "label": "Web Test Runner",
     "title": null,
     "route": "/guides/ecosystem/web-test-runner/",
@@ -606,6 +1869,7 @@
     },
     "imports": [],
     "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
@@ -614,12 +1878,12 @@
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/884562519.css",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css"
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
     ],
-    "pagePath": "./guides/ecosystem/web-test-runner.md",
-    "outputPath": "/guides/ecosystem/web-test-runner/index.html",
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/guides/ecosystem/web-test-runner.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/guides/ecosystem/web-test-runner/index.html",
     "isSSR": false,
     "prerender": true,
     "isolation": false,
@@ -627,6 +1891,7 @@
     "servePage": null
   },
   {
+    "id": "guides-getting-started-going-further",
     "label": "Going Further",
     "title": null,
     "route": "/guides/getting-started/going-further/",
@@ -643,6 +1908,7 @@
     },
     "imports": [],
     "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
@@ -651,12 +1917,12 @@
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/884562519.css",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css"
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
     ],
-    "pagePath": "./guides/getting-started/going-further.md",
-    "outputPath": "/guides/getting-started/going-further/index.html",
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/guides/getting-started/going-further.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/guides/getting-started/going-further/index.html",
     "isSSR": false,
     "prerender": true,
     "isolation": false,
@@ -664,6 +1930,7 @@
     "servePage": null
   },
   {
+    "id": "guides-getting-started-index",
     "label": "Getting Started",
     "title": null,
     "route": "/guides/getting-started/",
@@ -672,7 +1939,6 @@
       "order": 1,
       "tocHeading": 2,
       "tableOfContents": [
-        { "content": "What to Expect", "slug": "what-to-expect", "lvl": 2, "i": 0, "seen": 0 },
         { "content": "Prerequisites", "slug": "prerequisites", "lvl": 2, "i": 1, "seen": 0 },
         { "content": "Setup", "slug": "setup", "lvl": 2, "i": 2, "seen": 0 },
         { "content": "Jump Right In", "slug": "jump-right-in", "lvl": 2, "i": 3, "seen": 0 },
@@ -681,6 +1947,7 @@
     },
     "imports": [],
     "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
@@ -689,12 +1956,12 @@
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/884562519.css",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css"
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
     ],
-    "pagePath": "./guides/getting-started/index.md",
-    "outputPath": "/guides/getting-started/index.html",
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/guides/getting-started/index.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/guides/getting-started/index.html",
     "isSSR": false,
     "prerender": true,
     "isolation": false,
@@ -702,6 +1969,7 @@
     "servePage": null
   },
   {
+    "id": "guides-getting-started-key-concepts",
     "label": "Key Concepts",
     "title": "Key Concepts",
     "route": "/guides/getting-started/key-concepts/",
@@ -738,6 +2006,7 @@
     },
     "imports": [],
     "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
@@ -746,12 +2015,12 @@
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/884562519.css",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css"
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
     ],
-    "pagePath": "./guides/getting-started/key-concepts.md",
-    "outputPath": "/guides/getting-started/key-concepts/index.html",
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/guides/getting-started/key-concepts.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/guides/getting-started/key-concepts/index.html",
     "isSSR": false,
     "prerender": true,
     "isolation": false,
@@ -759,6 +2028,7 @@
     "servePage": null
   },
   {
+    "id": "guides-getting-started-next-steps",
     "label": "Next Steps",
     "title": null,
     "route": "/guides/getting-started/next-steps/",
@@ -766,6 +2036,7 @@
     "data": { "order": 4, "tocHeading": 2, "tableOfContents": [] },
     "imports": [],
     "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
@@ -774,12 +2045,12 @@
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/884562519.css",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css"
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
     ],
-    "pagePath": "./guides/getting-started/next-steps.md",
-    "outputPath": "/guides/getting-started/next-steps/index.html",
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/guides/getting-started/next-steps.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/guides/getting-started/next-steps/index.html",
     "isSSR": false,
     "prerender": true,
     "isolation": false,
@@ -787,6 +2058,7 @@
     "servePage": null
   },
   {
+    "id": "guides-getting-started-walkthrough",
     "label": "Walkthrough",
     "title": null,
     "route": "/guides/getting-started/walkthrough/",
@@ -811,6 +2083,7 @@
     },
     "imports": [],
     "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
@@ -819,12 +2092,12 @@
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/884562519.css",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css"
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
     ],
-    "pagePath": "./guides/getting-started/walkthrough.md",
-    "outputPath": "/guides/getting-started/walkthrough/index.html",
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/guides/getting-started/walkthrough.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/guides/getting-started/walkthrough/index.html",
     "isSSR": false,
     "prerender": true,
     "isolation": false,
@@ -832,6 +2105,7 @@
     "servePage": null
   },
   {
+    "id": "guides-hosting-aws",
     "label": "AWS",
     "title": "AWS",
     "route": "/guides/hosting/aws/",
@@ -847,6 +2121,7 @@
     },
     "imports": [],
     "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
@@ -855,12 +2130,12 @@
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/884562519.css",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css"
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
     ],
-    "pagePath": "./guides/hosting/aws.md",
-    "outputPath": "/guides/hosting/aws/index.html",
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/guides/hosting/aws.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/guides/hosting/aws/index.html",
     "isSSR": false,
     "prerender": true,
     "isolation": false,
@@ -868,6 +2143,7 @@
     "servePage": null
   },
   {
+    "id": "guides-hosting-cloudflare",
     "label": "Cloudflare",
     "title": "Cloudflare",
     "route": "/guides/hosting/cloudflare/",
@@ -882,6 +2158,7 @@
     },
     "imports": [],
     "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
@@ -890,12 +2167,12 @@
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/884562519.css",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css"
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
     ],
-    "pagePath": "./guides/hosting/cloudflare.md",
-    "outputPath": "/guides/hosting/cloudflare/index.html",
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/guides/hosting/cloudflare.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/guides/hosting/cloudflare/index.html",
     "isSSR": false,
     "prerender": true,
     "isolation": false,
@@ -903,6 +2180,7 @@
     "servePage": null
   },
   {
+    "id": "guides-hosting-github",
     "label": "GitHub",
     "title": "GitHub",
     "route": "/guides/hosting/github/",
@@ -918,6 +2196,7 @@
     },
     "imports": [],
     "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
@@ -926,12 +2205,12 @@
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/884562519.css",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css"
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
     ],
-    "pagePath": "./guides/hosting/github.md",
-    "outputPath": "/guides/hosting/github/index.html",
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/guides/hosting/github.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/guides/hosting/github/index.html",
     "isSSR": false,
     "prerender": true,
     "isolation": false,
@@ -939,6 +2218,7 @@
     "servePage": null
   },
   {
+    "id": "guides-hosting-index",
     "label": "Hosting",
     "title": null,
     "route": "/guides/hosting/",
@@ -947,7 +2227,6 @@
       "order": 2,
       "tocHeading": 2,
       "tableOfContents": [
-        { "content": "Building", "slug": "building", "lvl": 2, "i": 0, "seen": 0 },
         { "content": "Static Hosting", "slug": "static-hosting", "lvl": 2, "i": 1, "seen": 0 },
         { "content": "Self Hosting", "slug": "self-hosting", "lvl": 2, "i": 2, "seen": 0 },
         { "content": "Serverless", "slug": "serverless", "lvl": 2, "i": 3, "seen": 0 },
@@ -956,6 +2235,7 @@
     },
     "imports": [],
     "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
@@ -964,12 +2244,12 @@
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/884562519.css",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css"
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
     ],
-    "pagePath": "./guides/hosting/index.md",
-    "outputPath": "/guides/hosting/index.html",
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/guides/hosting/index.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/guides/hosting/index.html",
     "isSSR": false,
     "prerender": true,
     "isolation": false,
@@ -977,6 +2257,7 @@
     "servePage": null
   },
   {
+    "id": "guides-hosting-netlify",
     "label": "Netlify",
     "title": "Netlify",
     "route": "/guides/hosting/netlify/",
@@ -991,6 +2272,7 @@
     },
     "imports": [],
     "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
@@ -999,12 +2281,12 @@
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/884562519.css",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css"
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
     ],
-    "pagePath": "./guides/hosting/netlify.md",
-    "outputPath": "/guides/hosting/netlify/index.html",
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/guides/hosting/netlify.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/guides/hosting/netlify/index.html",
     "isSSR": false,
     "prerender": true,
     "isolation": false,
@@ -1012,6 +2294,7 @@
     "servePage": null
   },
   {
+    "id": "guides-hosting-vercel",
     "label": "Vercel",
     "title": "Vercel",
     "route": "/guides/hosting/vercel/",
@@ -1026,6 +2309,7 @@
     },
     "imports": [],
     "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
@@ -1034,12 +2318,12 @@
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/884562519.css",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css"
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
     ],
-    "pagePath": "./guides/hosting/vercel.md",
-    "outputPath": "/guides/hosting/vercel/index.html",
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/guides/hosting/vercel.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/guides/hosting/vercel/index.html",
     "isSSR": false,
     "prerender": true,
     "isolation": false,
@@ -1047,6 +2331,7 @@
     "servePage": null
   },
   {
+    "id": "guides-index",
     "label": "Guides",
     "title": "Guides",
     "route": "/guides/",
@@ -1054,6 +2339,7 @@
     "data": { "collection": "nav", "order": 2, "tocHeading": 0, "tableOfContents": [] },
     "imports": [],
     "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
@@ -1062,12 +2348,12 @@
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/884562519.css",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css"
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
     ],
-    "pagePath": "./guides/index.md",
-    "outputPath": "/guides/index.html",
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/guides/index.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/guides/index.html",
     "isSSR": false,
     "prerender": true,
     "isolation": false,
@@ -1075,6 +2361,7 @@
     "servePage": null
   },
   {
+    "id": "guides-tutorials-full-stack-web-components",
     "label": "Full Stack Web Components",
     "title": null,
     "route": "/guides/tutorials/full-stack-web-components/",
@@ -1094,6 +2381,7 @@
     },
     "imports": [],
     "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
@@ -1102,12 +2390,12 @@
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/884562519.css",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css"
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
     ],
-    "pagePath": "./guides/tutorials/full-stack-web-components.md",
-    "outputPath": "/guides/tutorials/full-stack-web-components/index.html",
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/guides/tutorials/full-stack-web-components.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/guides/tutorials/full-stack-web-components/index.html",
     "isSSR": false,
     "prerender": true,
     "isolation": false,
@@ -1115,6 +2403,7 @@
     "servePage": null
   },
   {
+    "id": "guides-tutorials-index",
     "label": "Tutorials",
     "title": null,
     "route": "/guides/tutorials/",
@@ -1122,6 +2411,7 @@
     "data": { "order": 4, "tocHeading": 0, "tableOfContents": [] },
     "imports": [],
     "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
@@ -1130,12 +2420,12 @@
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/884562519.css",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css"
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
     ],
-    "pagePath": "./guides/tutorials/index.md",
-    "outputPath": "/guides/tutorials/index.html",
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/guides/tutorials/index.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/guides/tutorials/index.html",
     "isSSR": false,
     "prerender": true,
     "isolation": false,
@@ -1143,6 +2433,7 @@
     "servePage": null
   },
   {
+    "id": "guides-tutorials-theme-packs",
     "label": "Theme Packs",
     "title": "Creating a Theme Pack",
     "route": "/guides/tutorials/theme-packs/",
@@ -1174,6 +2465,7 @@
     },
     "imports": [],
     "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
@@ -1182,12 +2474,12 @@
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/side-nav/side-nav.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/table-of-contents/table-of-contents.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/edit-on-github/edit-on-github.js",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/884562519.css",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css"
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/docs.css"
     ],
-    "pagePath": "./guides/tutorials/theme-packs.md",
-    "outputPath": "/guides/tutorials/theme-packs/index.html",
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/guides/tutorials/theme-packs.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/guides/tutorials/theme-packs/index.html",
     "isSSR": false,
     "prerender": true,
     "isolation": false,
@@ -1195,11 +2487,25 @@
     "servePage": null
   },
   {
+    "id": "index",
     "label": "Home",
     "title": null,
     "route": "/",
     "layout": "page",
-    "data": { "tocHeading": 0, "tableOfContents": [] },
+    "data": {
+      "imports": [
+        "../components/latest-post/latest-post.js data-gwd-opt=\"static\" type=\"module\"",
+        "../components/hero-banner/hero-banner.js data-gwd-opt=\"static\" type=\"module\"",
+        "../components/capabilities/capabilities.js type=\"module\"",
+        "../components/why-greenwood/why-greenwood.js data-gwd-opt=\"static\" type=\"module\"",
+        "../components/run-anywhere/run-anywhere.js data-gwd-opt=\"static\" type=\"module\"",
+        "../components/build-with-friends/build-with-friends.js data-gwd-opt=\"static\" type=\"module\"",
+        "../components/get-started/get-started.js data-gwd-opt=\"static\" type=\"module\"",
+        "../styles/home.css"
+      ],
+      "tocHeading": 0,
+      "tableOfContents": []
+    },
     "imports": [
       "../components/latest-post/latest-post.js data-gwd-opt=\"static\" type=\"module\"",
       "../components/hero-banner/hero-banner.js data-gwd-opt=\"static\" type=\"module\"",
@@ -1211,6 +2517,7 @@
       "../styles/home.css"
     ],
     "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
@@ -1222,12 +2529,12 @@
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/run-anywhere/run-anywhere.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/build-with-friends/build-with-friends.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/get-started/get-started.js",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/home.css"
     ],
-    "pagePath": "./index.md",
-    "outputPath": "/index.html",
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/index.md",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/index.html",
     "isSSR": false,
     "prerender": true,
     "isolation": false,
@@ -1235,24 +2542,26 @@
     "servePage": null
   },
   {
-    "outputPath": "/404.html",
-    "pagePath": "./src/404.html",
+    "id": "404",
+    "outputHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/public/404.html",
     "route": "/404/",
     "label": "Not Found",
     "title": "Page Not Found",
     "data": {},
     "imports": [],
     "resources": [
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1943356585.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/758806547.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/footer/footer.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/header/header.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/components/copy-to-clipboard/copy-to-clipboard.js",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1107222808.css",
-      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/1034023921.css",
+      "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/.greenwood/557264141.css",
       "/Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/styles/theme.css"
     ],
     "prerender": true,
     "isolation": false,
+    "pageHref": "file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/src/pages/404.html",
     "path": "404.html"
   }
 ]


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

resolves #88

## Summary of Changes

1. Pull header navigation from content as data using a navigation collection
1. Add active link underline styles

## TODO
1. [x] Tests will fail until #31 is merged (then will need to add docs to the collection, which should fix the ordering)
1. [x] Should get merged after #107 to account for latest Content as Data API changes
