### PR TITLE
content/blog post init code block and scrollbar styling

### DIFF
--- a/src/pages/blog/release/v0-30-0.md
+++ b/src/pages/blog/release/v0-30-0.md
@@ -167,9 +167,15 @@ The above highlights are by no means the only features delivered in this release
 
 ### Init Refresh
 
-We gave the initial scaffolding output when running our `@greenwood/init` command a refresh. It now comes with some useful starter code and links to the website for common documentation resources. Try it out today using `npx @greenwood/init@latest my-app`!
+We gave the initial scaffolding output when running our `@greenwood/init` command a refresh. It now comes with some useful starter code and links to the website for common documentation resources.
 
 ![Greenwood Init Refresh](/assets/blog/greenwood-init-refresh.webp)
+
+Try it out today!
+
+```shell
+$ npx @greenwood/init@latest my-app
+```
 
 ### Lit SSR Enhancements
 

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -91,6 +91,8 @@ pre {
   padding: 0px 4px;
   display: inline-block;
   border-radius: var(--radius-2);
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-gray) transparent;
 }
 
 [popover] {


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

N / A

Noticed the `npx` call out on mobile looked funny and had odd word wrapping on the latest blog post

<img width="460" alt="Screenshot 2024-11-08 at 21 35 58" src="https://github.com/user-attachments/assets/1054b325-bdff-4994-a8f6-ad747905e9a1">


## Summary of Changes

1. Shifted the content around a bit in the blog post to handle the word wrapping
1. Add general scrollbar styles on code blocks

<img width="674" alt="Screenshot 2024-11-08 at 21 55 25" src="https://github.com/user-attachments/assets/99b8abed-35bf-40c2-9f2b-5c10b0255868">