### PR TITLE
Fix typo in pages data docs example

### DIFF
--- a/src/pages/docs/content-as-data/pages-data.md
+++ b/src/pages/docs/content-as-data/pages-data.md
@@ -89,7 +89,7 @@ We would get this additional content as data out:
       },
       {
         "content": "First Point",
-        "slug": "first-post"
+        "slug": "first-point"
       }
     ]
   }


### PR DESCRIPTION

## Summary of Changes

1. [x] Fixed typo. I *think* `first-post` should be `first-point`, if I'm understanding the docs correctly.
