### PR TITLE
Escape angle brackets for Plugins API reference docs

### DIFF
--- a/src/pages/docs/reference/plugins-api.md
+++ b/src/pages/docs/reference/plugins-api.md
@@ -692,6 +692,6 @@ public/
 
 And accessible at the following routes in the browser:
 
-- _/artists/<name1>/_
-- _/artists/<name2>/_
-- _/artists/<nameN>/_
+- _/artists/\<name1\>/_
+- _/artists/\<name2\>/_
+- _/artists/\<nameN\>/_

--- a/src/pages/docs/reference/plugins-api.md
+++ b/src/pages/docs/reference/plugins-api.md
@@ -692,6 +692,6 @@ public/
 
 And accessible at the following routes in the browser:
 
-- _/artists/\<name1\>/_
-- _/artists/\<name2\>/_
-- _/artists/\<nameN\>/_
+- _/artists/&lt;name1&gt;/_
+- _/artists/&lt;name2&gt;/_
+- _/artists/&lt;nameN&gt;/_


### PR DESCRIPTION
## Summary of Changes

1. [x] Escaped angle brackets so that `<name*>` would display properly.

