### PR TITLE
Attempt to fix hiding of attribute described in markdown.

### DIFF
--- a/src/pages/guides/getting-started/going-further.md
+++ b/src/pages/guides/getting-started/going-further.md
@@ -37,7 +37,7 @@ Now if we look in the HTML output for any of our pages, we will see pre-rendered
 </app-footer>
 ```
 
-We can go one step further and instruct Greenwood to strip out the `<script>` tags for these components by adding the `data-gwd-opt="static"` attribute to them, since we have no need for any interactivity on these components.
+We can go one step further and instruct Greenwood to strip out the `<script>` tags for these components by adding the `data-gwd-opt=&quot;static&quot;` attribute to them, since we have no need for any interactivity on these components.
 
 ```html
 <script type="module" src="../components/footer/footer.js" data-gwd-opt="static"></script>


### PR DESCRIPTION
## Summary of Changes

1. [x] Attempted to fix the fact that an attribute described in MD was not being rendered. It renders correctly on GitHub but not on the docs site, presumably due to different MD flavors.
