### PR TITLE
docs/make Lit SSR `HTMLElement` caveat more up-front

### DIFF
--- a/src/pages/docs/plugins/lit-ssr.md
+++ b/src/pages/docs/plugins/lit-ssr.md
@@ -8,7 +8,7 @@ tocHeading: 2
 
 # Lit SSR
 
-A plugin for using [**Lit**'s SSR capabilities](https://github.com/lit/lit/tree/main/packages/labs/ssr) as a custom server-side renderer _instead_ of Greenwood's default renderer (WCC), which means **_you will need to use `LitElement` as your base class in all instances_** when using this plugin. This plugin also gives the ability to statically generate entire pages and layouts to output completely static sites (SSG). See the [plugin's README](https://github.com/ProjectEvergreen/greenwood/tree/master/packages/plugin-renderer-lit) for complete usage information and additional [usage caveats](https://github.com/ProjectEvergreen/greenwood/tree/master/packages/plugin-renderer-lit#caveats).
+A plugin for using [**Lit**'s SSR capabilities](https://github.com/lit/lit/tree/main/packages/labs/ssr) as a custom server-side renderer _instead_ of Greenwood's default renderer (WCC), which means **_you will need to use `LitElement` as your base class in all instances where you are pre-rendering or using SSR_**. This plugin also gives the ability to statically generate entire pages and layouts to output completely static sites (SSG). See the [plugin's README](https://github.com/ProjectEvergreen/greenwood/tree/master/packages/plugin-renderer-lit) for complete usage information and additional [usage caveats](https://github.com/ProjectEvergreen/greenwood/tree/master/packages/plugin-renderer-lit#caveats).
 
 ## Prerequisite
 

--- a/src/pages/docs/plugins/lit-ssr.md
+++ b/src/pages/docs/plugins/lit-ssr.md
@@ -8,7 +8,7 @@ tocHeading: 2
 
 # Lit SSR
 
-A plugin for using [**Lit**'s SSR capabilities](https://github.com/lit/lit/tree/main/packages/labs/ssr) as a custom server-side renderer instead of Greenwood's default renderer (WCC). This plugin also gives the ability to statically render entire pages and layouts to output completely static sites. See the [plugin's README](https://github.com/ProjectEvergreen/greenwood/tree/master/packages/plugin-renderer-lit) for complete usage information, in particular the [caveats section](https://github.com/ProjectEvergreen/greenwood/tree/master/packages/plugin-renderer-lit#caveats).
+A plugin for using [**Lit**'s SSR capabilities](https://github.com/lit/lit/tree/main/packages/labs/ssr) as a custom server-side renderer _instead_ of Greenwood's default renderer (WCC), which means **_you will need to use `LitElement` as your base class in all instances_** when using this plugin. This plugin also gives the ability to statically generate entire pages and layouts to output completely static sites (SSG). See the [plugin's README](https://github.com/ProjectEvergreen/greenwood/tree/master/packages/plugin-renderer-lit) for complete usage information and additional [usage caveats](https://github.com/ProjectEvergreen/greenwood/tree/master/packages/plugin-renderer-lit#caveats).
 
 ## Prerequisite
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

https://github.com/ProjectEvergreen/greenwood/pull/1337

## Summary of Changes

1. Per feedback, it was clear that this limitation needed to made more obvious up-front
