### PR TITLE
docs/issue 145 updates for PostCSS plugin ESM only configuration

### DIFF
--- a/src/pages/docs/plugins/postcss.md
+++ b/src/pages/docs/plugins/postcss.md
@@ -51,32 +51,15 @@ Then add this plugin to your _greenwood.config.js_.
 
 <!-- prettier-ignore-end -->
 
-To use your own PostCSS configuration, you'll need to create _two (2)_ config files in the root of your project, by which you can provide your own custom plugins / settings that you've installed.
-
-- _postcss.config.js_
-- _postcss.config.mjs_
-
-<!-- prettier-ignore-start -->
-
-<app-ctc-block variant="snippet" heading="postcss.config.mjs">
-
-  ```js
-  export default {
-    plugins: [(await import("autoprefixer")).default],
-  };
-  ```
-
-</app-ctc-block>
-
-<!-- prettier-ignore-end -->
+To use your own PostCSS configuration, just create a _postcss.config.js_ file at the root of your project, by which you can provide your own custom plugins / settings that you've installed.
 
 <!-- prettier-ignore-start -->
 
 <app-ctc-block variant="snippet" heading="postcss.config.js">
 
   ```js
-  module.exports = {
-    plugins: [require("autoprefixer")],
+  export default {
+    plugins: [(await import("autoprefixer")).default],
   };
   ```
 
@@ -101,6 +84,7 @@ Now you can write CSS
   .image {
     background-image: url(image@1x.png);
   }
+
   @media (min-resolution: 2dppx) {
     .image {
       background-image: url(image@2x.png);

--- a/src/pages/guides/ecosystem/storybook.md
+++ b/src/pages/guides/ecosystem/storybook.md
@@ -128,7 +128,7 @@ export default {
 
 You'll want to create a CommonJS version with the following name, depending on which version of Storybook you are using:
 
-- Storybook >= 8 - _postcss.config.js_
+- Storybook >= 8 - _postcss.config.cjs_
 - Storybook <= 7 - _.postcssrc.js_
 
 ```js

--- a/src/pages/guides/ecosystem/storybook.md
+++ b/src/pages/guides/ecosystem/storybook.md
@@ -131,11 +131,19 @@ You'll want to create a CommonJS version with the following name, depending on w
 - Storybook >= 8 - _postcss.config.cjs_
 - Storybook <= 7 - _.postcssrc.js_
 
-```js
-module.exports = {
-  plugins: [require("tailwindcss"), require("autoprefixer")],
-};
-```
+<!-- prettier-ignore-start -->
+
+<app-ctc-block variant="snippet">
+
+  ```js
+  module.exports = {
+    plugins: [require("tailwindcss"), require("autoprefixer")],
+  };
+  ```
+
+</app-ctc-block>
+
+<!-- prettier-ignore-end -->
 
 ## Import Attributes
 

--- a/src/pages/guides/ecosystem/storybook.md
+++ b/src/pages/guides/ecosystem/storybook.md
@@ -114,6 +114,26 @@ To help with resolving any static assets used in your stories, you can configure
 
 <!-- prettier-ignore-end -->
 
+## PostCSS
+
+If you are using Greenwood's [PostCSS plugin](/docs/plugins/postcss/), you'll need to create a secondary CommonJS compatible configuration file for Storybook.
+
+So if your current _postcss.config.js_ looks like this:
+
+```js
+export default {
+  plugins: [(await import("tailwindcss")).default, (await import("autoprefixer")).default],
+};
+```
+
+You'll want to create a _.postcssrc.js_ file using CJS syntax:
+
+```js
+module.exports = {
+  plugins: [require("tailwindcss"), require("autoprefixer")],
+};
+```
+
 ## Import Attributes
 
 As [Vite does not support Import Attributes](https://github.com/vitejs/vite/issues/14674), we will need to create a _vite.config.js_ and write a [custom plugin](https://vitejs.dev/guide/api-plugin) to work around this.

--- a/src/pages/guides/ecosystem/storybook.md
+++ b/src/pages/guides/ecosystem/storybook.md
@@ -126,7 +126,10 @@ export default {
 };
 ```
 
-You'll want to create a _.postcssrc.js_ file using CJS syntax:
+You'll want to create a CommonJS version called with the following name, depending on which version of Storybook you are using:
+
+- Storybook >= 8 - _postcss.config.js_
+- Storybook <= 7 - _.postcssrc.js_
 
 ```js
 module.exports = {

--- a/src/pages/guides/ecosystem/storybook.md
+++ b/src/pages/guides/ecosystem/storybook.md
@@ -126,7 +126,7 @@ export default {
 };
 ```
 
-You'll want to create a CommonJS version called with the following name, depending on which version of Storybook you are using:
+You'll want to create a CommonJS version with the following name, depending on which version of Storybook you are using:
 
 - Storybook >= 8 - _postcss.config.js_
 - Storybook <= 7 - _.postcssrc.js_

--- a/src/pages/guides/ecosystem/tailwind.md
+++ b/src/pages/guides/ecosystem/tailwind.md
@@ -50,28 +50,11 @@ As Tailwind is a PostCSS plugin, you'll need to take a couple of extra steps to 
 
   <!-- prettier-ignore-end -->
 
-1. Create _**two**_ PostCSS configuration files (two files are needed in Greenwood to support ESM / CJS interop)
+1. Create a [PostCSS configuration file](/docs/plugins/postcss/#installation) in the root of your project with needed Tailwind plugins
 
   <!-- prettier-ignore-start -->
 
   <app-ctc-block variant="snippet" heading="postcss.config.js">
-
-    ```js
-    module.exports = {
-      plugins: {
-        tailwindcss: {},
-        autoprefixer: {},
-      },
-    };
-    ```
-
-  </app-ctc-block>
-
-  <!-- prettier-ignore-end -->
-
-  <!-- prettier-ignore-start -->
-
-  <app-ctc-block variant="snippet" heading="postcss.config.mjs">
 
     ```js
     export default {


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

resolves #145 

## Summary of Changes

1. Document ESM only PostCSS configuration
1. Align Tailwind guide
1. Add CJS callout to Storybook docs

## TODO
1. [x] For Storybook compatibility, need to retain CJS configuration as _.postcssrc.js_ - https://github.com/AnalogStudiosRI/www.tuesdaystunes.tv/pull/132/files#diff-119a7b763b4d6085e505055ab9e4af687a93a8f0b8d204f59788e999062fd1b0
1. [x] Update Tailwind configuration (also recommend extending Greenwood's default config - https://github.com/AnalogStudiosRI/www.tuesdaystunes.tv/blob/main/greenwood.config.js#L7
1. [x] Looks like for Storybook v8 we will still want _.cjs_ PostCSS configuration file - https://github.com/AnalogStudiosRI/www.blissri.com/pull/55
1. [x] has to merged _after_ and updated for snippets added in this PR - https://github.com/ProjectEvergreen/www.greenwoodjs.dev/pull/120