### PR TITLE
docs/issue 149 clarify renderer plugin prerendering usage and options

### DIFF
--- a/src/pages/docs/reference/plugins-api.md
+++ b/src/pages/docs/reference/plugins-api.md
@@ -331,7 +331,9 @@ If you need to copy files out of _node_modules_, you can use some of Greenwood's
 
 ## Renderer
 
-Renderer plugins allow users to customize how Greenwood server renders (and prerenders) your project. By default, Greenwood supports using [**WCC** or (template) strings](/docs/pages/server-rendering/) to return static HTML for the content and template of your server side routes. With this plugin for example, you can use [Lit's SSR](https://github.com/lit/lit/tree/main/packages/labs/ssr) to render your Lit Web Components on the server side instead. (but don't do that one specifically, we already have [a plugin](/docs/plugins/lit-ssr/) for Lit 😊)
+Renderer plugins allow users to customize how Greenwood server renders (and prerenders) your project. By default, Greenwood supports using [**WCC** or (template) strings](/docs/pages/server-rendering/) to return static HTML for the content and template of your server side routes. For example, you can use [Lit's SSR capabilities](https://github.com/lit/lit/tree/main/packages/labs/ssr) to render your Lit Web Components on the server side instead. (but don't do that one specifically, we already have [a plugin](/docs/plugins/lit-ssr/) for Lit 😊)
+
+> Note: Only **one** renderer plugin can be used at a time.
 
 ### API
 
@@ -342,14 +344,13 @@ This plugin expects to be given a path to a module that exports a function to ex
 <app-ctc-block variant="snippet" heading="my-renderer-plugin.js">
 
   ```js
-  const greenwoodPluginMyCustomRenderer = (options = {}) => {
+  const greenwoodPluginMyCustomRenderer = () => {
     return {
       type: "renderer",
       name: "plugin-renderer-custom",
       provider: () => {
         return {
           executeModuleUrl: new URL("./execute-route-module.js", import.meta.url),
-          prerender: options.prerender,
         };
       },
     };
@@ -362,13 +363,14 @@ This plugin expects to be given a path to a module that exports a function to ex
 
 <!-- prettier-ignore-end -->
 
+<!-- eslint-enable no-unused-vars -->
+
 #### Options
 
 This plugin type supports the following options:
 
 - **executeModuleUrl** (recommended) - `URL` to the location of a file with the SSR rendering implementation
 - **customUrl** - `URL` to a file that has a `default export` of a function for handling the _prerendering_ lifecyle of a Greenwood build, and running the provided callback function
-- **prerender** (optional) - Flag can be used to indicate if this custom renderer should be used to statically [prerender](/docs/reference/configuration/#prerender) pages too.
 
 ### Examples
 

--- a/src/pages/docs/reference/plugins-api.md
+++ b/src/pages/docs/reference/plugins-api.md
@@ -331,7 +331,7 @@ If you need to copy files out of _node_modules_, you can use some of Greenwood's
 
 ## Renderer
 
-Renderer plugins allow users to customize how Greenwood server renders (and prerenders) your project. By default, Greenwood supports using [**WCC** or (template) strings](/docs/pages/server-rendering/) to return static HTML for the content and template of your server side routes. For example, you can use [Lit's SSR capabilities](https://github.com/lit/lit/tree/main/packages/labs/ssr) to render your Lit Web Components on the server side instead. (but don't do that one specifically, we already have [a plugin](/docs/plugins/lit-ssr/) for Lit 😊)
+Renderer plugins are the way to customize how Greenwood server renders (and prerenders) your project. By default, Greenwood supports using [**WCC** or (template) strings](/docs/pages/server-rendering/) to return static HTML for the content and layouts of your server side routes. For example, you can use [Lit's SSR capabilities](https://github.com/lit/lit/tree/main/packages/labs/ssr) to render your Lit Web Components on the server side instead. (but don't do that one specifically, we already have [a plugin](/docs/plugins/lit-ssr/) for Lit 😊)
 
 > Note: Only **one** renderer plugin can be used at a time.
 
@@ -370,7 +370,7 @@ This plugin expects to be given a path to a module that exports a function to ex
 This plugin type supports the following options:
 
 - **executeModuleUrl** (recommended) - `URL` to the location of a file with the SSR rendering implementation
-- **customUrl** - `URL` to a file that has a `default export` of a function for handling the _prerendering_ lifecyle of a Greenwood build, and running the provided callback function
+- **customUrl** - `URL` to a file that has a `default export` of a function for handling the _prerendering_ lifecycle of a Greenwood build, and running the provided callback function
 
 ### Examples
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

resolves #149 

## Summary of Changes

1. Remove plugin specific option for `prerender` (is now controlled entirely from the setting in _greenwood.config.js_)
1. Call out that only one renderer plugin can be used at once

## TODO
1. [x] ~~Need to update the [reference section](https://github.com/ProjectEvergreen/www.greenwoodjs.dev/blob/main/src/pages/docs/reference/plugins-api.md#renderer) for plugins to not have a `prerender` option~~ -
    - I think this was just a mistake on my part, I see all the needed changes already in this PR 🤷‍♂️ 
1. [x] has to merged _after_ - https://github.com/ProjectEvergreen/www.greenwoodjs.dev/pull/120