### PR TITLE
docs/issue 144 best practices and recommendations for import maps and referencing node modules

### DIFF
--- a/src/pages/docs/introduction/about.md
+++ b/src/pages/docs/introduction/about.md
@@ -14,7 +14,7 @@ Greenwood's goal is to bring the power of the modern web right to your fingertip
 
 Some of Greenwood's feature include:
 
-- Unbundled local development workflow, using `ETag` headers for efficient caching and live reloads
+- Unbundled local development workflow, using `ETag` cache headers for efficient caching and live reloads
 - Out of the box support for ESM and Web APIs, on both the client and server
 - Server Side Rendering of Web Components (Light and Shadow DOM)
 - File-based routing, including API Routes

--- a/src/pages/docs/introduction/web-standards.md
+++ b/src/pages/docs/introduction/web-standards.md
@@ -104,7 +104,7 @@ export async function handler(request) {
 
 ## Import Maps
 
-During local development, Greenwood loads all assets from your browser unbundled, serving the content right off disk. [**Import maps**](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap) allow bare specifiers typically found when referencing packages from npm, to work natively in the browser. When installing a package as a **dependency** in your _package.json_, Greenwood will walk your dependencies and all their dependencies, to build up a map to be injected into the `<head>` of your HTML.
+During local development, Greenwood loads all assets from your browser unbundled, serving the content right off disk. [**Import Maps**](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap) allow bare specifiers typically found when referencing packages from npm, to work natively in the browser. When installing a package as a **dependency** in your _package.json_, Greenwood will walk your dependencies and all their dependencies, to build up a map to be injected into the `<head>` of your HTML.
 
 This is a sample of an import map that would be generated after having installed the **lit** package:
 
@@ -127,6 +127,23 @@ This is a sample of an import map that would be generated after having installed
   </body>
 </html>
 ```
+
+To generate this map, Greenwood first checks for package's [**exports**](https://nodejs.org/api/packages.html#package-entry-points) field, then looks for a **module** field, and finally a **main** field. For **exports**, Greenwood resolves the following [conditions](https://nodejs.org/api/packages.html#conditional-exports) in this priority order:
+
+1. **import**
+1. **module-sync**
+1. **default**
+
+### Compatibility
+
+It should be noted that not all packages are created equal, and Greenwood depends on packages following the standard conventions of the NodeJS entry point specification when looking up their location using `import.meta.resolve`. This means there are packages that may not behave as expected, though Greenwood will do its best to make them work. In these exceptional cases, Greenwood will output some diagnostic information that can be used when reaching out for help. Ideally, package authors would accept patches to correct any such issues.
+
+Some known issues / examples observed so far include:
+
+- `ERR_MODULE_NOT_FOUND` - Observed with packages like [**@types/trusted-types**](https://github.com/DefinitelyTyped/DefinitelyTyped), which has an [empty string](https://unpkg.com/browse/@types/trusted-types@2.0.7/package.json) for the **main** field, and [**font-awesome**](https://fontawesome.com/), which has [no entry point](https://unpkg.com/browse/font-awesome@4.7.0/package.json) at all, at least as of `v4.x`.
+- `ERR_PACKAGE_PATH_NOT_EXPORTED` - Encountered with the [**geist-font** package](https://vercel.com/font), which has [no default export](https://github.com/vercel/geist-font/issues/150) in its exports map
+
+In these cases where Greenwood cannot resolve these dependencies, it will fallback to assuming packages are located in a _node_modules_ folder at the root of your project. Depending on your package manager, you may need to ["hoist"](https://pnpm.io/npmrc#dependency-hoisting-settings) these dependencies, as might be the case when using PNPM.
 
 ## URL
 

--- a/src/pages/docs/introduction/web-standards.md
+++ b/src/pages/docs/introduction/web-standards.md
@@ -104,7 +104,7 @@ export async function handler(request) {
 
 ## Import Maps
 
-During local development, Greenwood serves all resources to your browser unbundled right off disk using efficient [E-Tag caching](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag). [**Import Maps**](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap) allow bare specifiers, typically found when referencing packages from npm, to work natively in the browser. When Greenwood sees a package in the **dependency** field of your _package.json_, Greenwood will walk all your dependencies and build up an import map to be injected into the `<head>` of your HTML automatically, in conjunction with Greenwood's dev server.
+During local development, Greenwood serves all resources to your browser unbundled right off disk using efficient [E-Tag caching](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag). [**Import Maps**](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap) allow bare specifiers for ESM compatible packages installed from npm to work natively in the browser. When Greenwood sees a package in the **dependency** field of your _package.json_, Greenwood will walk all your dependencies and build up an import map to be injected into the `<head>` of your HTML automatically, in conjunction with Greenwood's dev server.
 
 Below is a sample of an import map that would be generated after having installed the **lit** package:
 

--- a/src/pages/docs/introduction/web-standards.md
+++ b/src/pages/docs/introduction/web-standards.md
@@ -128,7 +128,7 @@ This is a sample of an import map that would be generated after having installed
 </html>
 ```
 
-To generate this map, Greenwood first checks for package's [**exports**](https://nodejs.org/api/packages.html#package-entry-points) field, then looks for a **module** field, and finally a **main** field. For **exports**, Greenwood resolves the following [conditions](https://nodejs.org/api/packages.html#conditional-exports) in this priority order:
+To generate this map, Greenwood first checks for a package's [**exports**](https://nodejs.org/api/packages.html#package-entry-points) field, then looks for a **module** field, and finally a **main** field. For **exports**, Greenwood resolves the following [conditions](https://nodejs.org/api/packages.html#conditional-exports) in this priority order:
 
 1. **import**
 1. **module-sync**
@@ -136,14 +136,14 @@ To generate this map, Greenwood first checks for package's [**exports**](https:/
 
 ### Compatibility
 
-It should be noted that not all packages are created equal, and Greenwood depends on packages following the standard conventions of the NodeJS entry point specification when looking up their location using `import.meta.resolve`. This means there are packages that may not behave as expected, though Greenwood will do its best to make them work. In these exceptional cases, Greenwood will output some diagnostic information that can be used when reaching out for help. Ideally, package authors would accept patches to correct any such issues.
+It should be noted that not all packages are created equal, and Greenwood depends on packages following the standard conventions of the NodeJS entry point specification when looking up their location using [`import.meta.resolve`](https://nodejs.org/api/esm.html#importmetaresolvespecifier). In these cases, like when having installed server-side packages in the `dependencies` field of your _package.json_ that _aren't_ intended to be used on the client side, Greenwood will output some diagnostic information that can be used when reaching out for help.
 
 Some known issues / examples observed so far include:
 
-- `ERR_MODULE_NOT_FOUND` - Observed with packages like [**@types/trusted-types**](https://github.com/DefinitelyTyped/DefinitelyTyped), which has an [empty string](https://unpkg.com/browse/@types/trusted-types@2.0.7/package.json) for the **main** field, and [**font-awesome**](https://fontawesome.com/), which has [no entry point](https://unpkg.com/browse/font-awesome@4.7.0/package.json) at all, at least as of `v4.x`.
-- `ERR_PACKAGE_PATH_NOT_EXPORTED` - Encountered with the [**geist-font** package](https://vercel.com/font), which has [no default export](https://github.com/vercel/geist-font/issues/150) in its exports map
+- `ERR_MODULE_NOT_FOUND` - Observed with packages like [**@types/trusted-types**](https://github.com/DefinitelyTyped/DefinitelyTyped) which has an [empty string](https://unpkg.com/browse/@types/trusted-types@2.0.7/package.json) for the **main** field, or [**font-awesome**](https://fontawesome.com/), which has [no entry point](https://unpkg.com/browse/font-awesome@4.7.0/package.json) at all, at least as of `v4.x`. This is also a fairly common issue with packages that primarily deal with shipping types since they will likely only define a `types` field in their _package.json_.
+- `ERR_PACKAGE_PATH_NOT_EXPORTED` - Encountered with packages like [**geist-font**](https://github.com/vercel/geist-font/issues/150) or [**@libsql/core**](https://github.com/thescientist13/import-meta-resolve-demo?tab=readme-ov-file#no-main-exports-map-entry-point-err_package_path_not_exported), which has [no default export](https://github.com/vercel/geist-font/issues/150) in their exports map, which is assumed by the NodeJS resolver algorithm.
 
-In these cases where Greenwood cannot resolve these dependencies, it will fallback to assuming packages are located in a _node_modules_ folder at the root of your project. Depending on your package manager, you may need to ["hoist"](https://pnpm.io/npmrc#dependency-hoisting-settings) these dependencies, as might be the case when using PNPM.
+> If you have any issues or questions, please reach out in our discussion on the topic here - https://github.com/ProjectEvergreen/greenwood/discussions/1396.
 
 ## URL
 

--- a/src/pages/docs/introduction/web-standards.md
+++ b/src/pages/docs/introduction/web-standards.md
@@ -104,9 +104,9 @@ export async function handler(request) {
 
 ## Import Maps
 
-During local development, Greenwood loads all assets from your browser unbundled, serving the content right off disk. [**Import Maps**](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap) allow bare specifiers typically found when referencing packages from npm, to work natively in the browser. When installing a package as a **dependency** in your _package.json_, Greenwood will walk your dependencies and all their dependencies, to build up a map to be injected into the `<head>` of your HTML.
+During local development, Greenwood serves all resources to your browser unbundled right off disk using efficient [E-Tag caching](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag). [**Import Maps**](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap) allow bare specifiers, typically found when referencing packages from npm, to work natively in the browser. When Greenwood sees a package in the **dependency** field of your _package.json_, Greenwood will walk all your dependencies and build up an import map to be injected into the `<head>` of your HTML automatically, in conjunction with Greenwood's dev server.
 
-This is a sample of an import map that would be generated after having installed the **lit** package:
+Below is a sample of an import map that would be generated after having installed the **lit** package:
 
 ```html
 <html>
@@ -128,7 +128,7 @@ This is a sample of an import map that would be generated after having installed
 </html>
 ```
 
-To generate this map, Greenwood first checks for a package's [**exports**](https://nodejs.org/api/packages.html#package-entry-points) field, then looks for a **module** field, and finally a **main** field. For **exports**, Greenwood resolves the following [conditions](https://nodejs.org/api/packages.html#conditional-exports) in this priority order:
+To generate this map, Greenwood first checks each package's [**exports**](https://nodejs.org/api/packages.html#package-entry-points) field, then looks for a **module** field, and finally a **main** field. If none of these fields are found, Greenwood will log some diagnostics information. For **exports** field, Greenwood supports the following [conditions](https://nodejs.org/api/packages.html#conditional-exports) in this priority order:
 
 1. **import**
 1. **module-sync**
@@ -136,14 +136,16 @@ To generate this map, Greenwood first checks for a package's [**exports**](https
 
 ### Compatibility
 
-It should be noted that not all packages are created equal, and Greenwood depends on packages following the standard conventions of the NodeJS entry point specification when looking up their location using [`import.meta.resolve`](https://nodejs.org/api/esm.html#importmetaresolvespecifier). In these cases, like when having installed server-side packages in the `dependencies` field of your _package.json_ that _aren't_ intended to be used on the client side, Greenwood will output some diagnostic information that can be used when reaching out for help.
+However in the land of _node_modules_, not all packages are created equal. Greenwood depends on packages following the standard conventions of the NodeJS entry point specification when resolving the location of dependencies on disk using [`import.meta.resolve`](https://nodejs.org/api/esm.html#importmetaresolvespecifier). For server-side only packages, this is is usually not an issue. Greenwood will output some diagnostic information that can be used when reaching out for help in case something ends up not working as expected, but if it works, it works!
 
 Some known issues / examples observed so far include:
 
 - `ERR_MODULE_NOT_FOUND` - Observed with packages like [**@types/trusted-types**](https://github.com/DefinitelyTyped/DefinitelyTyped) which has an [empty string](https://unpkg.com/browse/@types/trusted-types@2.0.7/package.json) for the **main** field, or [**font-awesome**](https://fontawesome.com/), which has [no entry point](https://unpkg.com/browse/font-awesome@4.7.0/package.json) at all, at least as of `v4.x`. This is also a fairly common issue with packages that primarily deal with shipping types since they will likely only define a `types` field in their _package.json_.
 - `ERR_PACKAGE_PATH_NOT_EXPORTED` - Encountered with packages like [**geist-font**](https://github.com/vercel/geist-font/issues/150) or [**@libsql/core**](https://github.com/thescientist13/import-meta-resolve-demo?tab=readme-ov-file#no-main-exports-map-entry-point-err_package_path_not_exported), which has [no default export](https://github.com/vercel/geist-font/issues/150) in their exports map, which is assumed by the NodeJS resolver algorithm.
 
-> If you have any issues or questions, please reach out in our discussion on the topic here - https://github.com/ProjectEvergreen/greenwood/discussions/1396.
+> In almost all of our observed diagnostic cases, they would all go away if [this feature](https://github.com/nodejs/node/issues/49445) was added to NodeJS, so please add an up-vote to that issue! 👍
+>
+> If you have any issues or questions, please reach out in our [discussion on the topic](https://github.com/ProjectEvergreen/greenwood/discussions/1396).
 
 ## URL
 

--- a/src/pages/docs/reference/plugins-api.md
+++ b/src/pages/docs/reference/plugins-api.md
@@ -289,20 +289,18 @@ This plugin supports providing an array of "paired" URL objects that can either 
 
 If you need to copy files out of _node_modules_, you can use some of Greenwood's helper utilities for locating npm packages on disk and copying them to the output directory. For [example](https://github.com/ProjectEvergreen/greenwood/blob/master/packages/plugin-polyfills/src/index.js):
 
-<!-- eslint-disable no-unused-vars -->
+<!-- prettier-ignore-start -->
 
-```js
-import {
-  derivePackageRoot,
-  resolveBareSpecifier,
-} from "@greenwood/cli/src/lib/walker-package-ranger.js";
+<app-ctc-block variant="snippet" heading="src/pages/index.html">
 
-const greenwoodPluginPolyfills = (options = {}) => {
-  return [
-    {
-      // ...
-    },
-    {
+  ```js
+  import {
+    derivePackageRoot,
+    resolveBareSpecifier,
+  } from "@greenwood/cli/src/lib/walker-package-ranger.js";
+
+  const greenwoodPluginPolyfills = () => {
+    return [{
       type: "copy",
       name: "plugin-copy-polyfills",
       provider: async (compilation) => {
@@ -310,7 +308,7 @@ const greenwoodPluginPolyfills = (options = {}) => {
         const polyfillsResolved = resolveBareSpecifier("@webcomponents/webcomponentsjs");
         const polyfillsRoot = derivePackageRoot(polyfillsResolved);
 
-        const standardPolyfills = [
+        return [
           {
             from: new URL("./webcomponents-loader.js", polyfillsRoot),
             to: new URL("./webcomponents-loader.js", outputDir),
@@ -320,15 +318,16 @@ const greenwoodPluginPolyfills = (options = {}) => {
             to: new URL("./bundles/", outputDir),
           },
         ];
-
-        // ...
       },
-    },
-  ];
-};
-```
+    }];
+  };
 
-<!-- eslint-enable no-unused-vars -->
+  export { greenwoodPluginPolyfills }
+  ```
+
+</app-ctc-block>
+
+<!-- prettier-ignore-end -->
 
 ## Renderer
 

--- a/src/pages/docs/reference/plugins-api.md
+++ b/src/pages/docs/reference/plugins-api.md
@@ -287,7 +287,48 @@ This plugin supports providing an array of "paired" URL objects that can either 
 
 <!-- prettier-ignore-end -->
 
-> You can see more examples in the [Greenwood repo](https://github.com/ProjectEvergreen/greenwood/tree/master/packages/cli/src/plugins/copy).
+If you need to copy files out of _node_modules_, you can use some of Greenwood's helper utilities for locating npm packages on disk and copying them to the output directory. For [example](https://github.com/ProjectEvergreen/greenwood/blob/master/packages/plugin-polyfills/src/index.js):
+
+<!-- eslint-disable no-unused-vars -->
+
+```js
+import {
+  derivePackageRoot,
+  resolveBareSpecifier,
+} from "@greenwood/cli/src/lib/walker-package-ranger.js";
+
+const greenwoodPluginPolyfills = (options = {}) => {
+  return [
+    {
+      // ...
+    },
+    {
+      type: "copy",
+      name: "plugin-copy-polyfills",
+      provider: async (compilation) => {
+        const { outputDir } = compilation.context;
+        const polyfillsResolved = resolveBareSpecifier("@webcomponents/webcomponentsjs");
+        const polyfillsRoot = derivePackageRoot(polyfillsResolved);
+
+        const standardPolyfills = [
+          {
+            from: new URL("./webcomponents-loader.js", polyfillsRoot),
+            to: new URL("./webcomponents-loader.js", outputDir),
+          },
+          {
+            from: new URL("./bundles/", polyfillsRoot),
+            to: new URL("./bundles/", outputDir),
+          },
+        ];
+
+        // ...
+      },
+    },
+  ];
+};
+```
+
+<!-- eslint-enable no-unused-vars -->
 
 ## Renderer
 
@@ -457,7 +498,7 @@ When requesting a resource like a file, such as _/main.js_, Greenwood needs to k
 
 When requesting a file and after knowing where to resolve it, such as _/path/to/user-workspace/main/scripts/main.js_, Greenwood needs to return the contents of that resource so can be served to a browser or bundled appropriately. This is done by passing an instance of `URL` and `Request` and returning an instance of `Response`. For example, Greenwood uses this lifecycle extensively to serve all the standard web content types like HTML, JS, CSS, images, fonts, etc and also providing the appropriate `Content-Type` header.
 
-If you are supporting _non standard_ file formats, like TypeScript (_.ts_) or JSX (_.jsx_), this is where you would want to handle providing the contents of this file transformed into something a browser could understand; like compiling the TypeScript to JavaScript.
+If you are supporting _non standard_ file formats, like TypeScript (_.ts_) or JSX (_.jsx_), this is where you would want to handle providing the contents of this file transformed into something a browser could understand; like compiling the TypeScript to JavaScript. This lifecycle is the right place to evaluate a predicate based on a file's extension.
 
 Below is an example from [Greenwood's codebase](https://github.com/ProjectEvergreen/greenwood/blob/master/packages/cli/src/plugins/resource/plugin-standard-javascript.js) for serving JavaScript files.
 

--- a/src/pages/docs/resources/scripts.md
+++ b/src/pages/docs/resources/scripts.md
@@ -49,7 +49,7 @@ Greenwood is ECMAScript Modules (ESM) first, as shown with the usage of the `typ
   <!doctype html>
   <html lang="en" prefix="og:http://ogp.me/ns#">
     <head>
-      <script type="module" src="./path/to/script.js"></script>
+      <script type="module" src="../path/to/script.js"></script>
     </head>
 
     <body>
@@ -62,9 +62,9 @@ Greenwood is ECMAScript Modules (ESM) first, as shown with the usage of the `typ
 
 <!-- prettier-ignore-end -->
 
-Keep in mind that the specification dictates the following conventions when referencing ESM files:
+Keep in mind that [the specification](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#module_specifier_resolution) dictates the following requirements when referencing ESM files:
 
-1. It must be a relative path
+1. It must be a relative specifier (starts with a `./`, `../`, or `/`)
 1. It must have an extension
 
 <!-- eslint-disable no-unused-vars -->
@@ -83,9 +83,9 @@ import { Foo } from "./foo";
 
 ## Node Modules
 
-Packages from [**npm**](https://www.npmjs.com/) (and compatible registries) can be used by installing them with your favorite package manager. In the browser, Greenwood will automatically build up an import map from any packages defined in the **dependencies** property of your _package.json_.
+Packages from [**npm**](https://www.npmjs.com/) (and compatible registries) can be used by installing them with your favorite package manager. In the browser, Greenwood will automatically build up an [import map](/docs/introduction/web-standards/#import-maps) so that you can use [bare specifiers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#module_specifier_resolution).
 
-Below are some examples:
+Below is an example of using a bare specifier in a JavaScript file:
 
 <!-- prettier-ignore-start -->
 
@@ -112,7 +112,7 @@ Below are some examples:
 
 <!-- prettier-ignore-end -->
 
-You can reference **node_modules** directly from a `<script>` tag by starting the path with `/node_modules`:
+You can reference **node_modules** directly from a `<script>` tag by starting the path with a "shortcut" alias of **/node_modules/**, which will signal to Greenwood to use `import.meta.resolve` to automatically resolve the full path for you:
 
 <!-- prettier-ignore-start -->
 
@@ -138,10 +138,8 @@ You can reference **node_modules** directly from a `<script>` tag by starting th
 
 <!-- prettier-ignore-end -->
 
-The rule of thumb is:
-
-- If it's a package from npm installed in **dependencies**, you can use bare specifiers and no extension
-- Otherwise, you will need to use a relative path and the extension
+> Relative paths will also work in this context if you are comfortable resolving the full path to _node_modules_ on your own, e.g.
+> `<script src="../../node_modules/htmx.org/dist/htmx.js"></script>`
 
 ## Prerendering
 

--- a/src/pages/docs/resources/styles.md
+++ b/src/pages/docs/resources/styles.md
@@ -60,7 +60,6 @@ Here is an example of using relative and shortcut paths in a CSS file:
   ```css
   /* after having installed Open Props */
   /* npm i open-props */
-  /* src/theme.css */
   @import "../../node_modules/open-props/borders.min.css";
   @import "../../node_modules/open-props/fonts.min.css";
 

--- a/src/pages/docs/resources/styles.md
+++ b/src/pages/docs/resources/styles.md
@@ -47,11 +47,11 @@ Styles can be done in any standards compliant way that will work in a browser. S
 
 <!-- prettier-ignore-end -->
 
-## NPM
+## Node Modules
 
-Packages from [**npm**](https://www.npmjs.com/) can be used by installing them with your favorite package manager.
+Like [with scripts](/docs/resources/scripts/#node-modules), packages from [**npm**](https://www.npmjs.com/) (and compatible registries) can be used by installing them with your favorite package manager. Similar conventions apply in regards to using the **/node_modules/** "shortcut" alias to let Greenwood resolve the location using `import.meta.resolve`, or you can provide the full relative path yourself.
 
-In a CSS file, you can use relative paths to resolve to _node_modules_:
+Here is an example of using relative and shortcut paths in a CSS file:
 
 <!-- prettier-ignore-start -->
 
@@ -60,17 +60,20 @@ In a CSS file, you can use relative paths to resolve to _node_modules_:
   ```css
   /* after having installed Open Props */
   /* npm i open-props */
-  @import "../../node_modules/open-props/src/props.borders.css";
-  @import "../../node_modules/open-props/src/props.fonts.css";
-  @import "../../node_modules/open-props/src/props.shadows.css";
-  @import "../../node_modules/open-props/src/props.sizes.css";
+  /* src/theme.css */
+  @import "../../node_modules/open-props/borders.min.css";
+  @import "../../node_modules/open-props/fonts.min.css";
+
+  /* this would also work */
+  @import "/node_modules/open-props/borders.min.css";
+  @import "/node_modules/open-props/fonts.min.css";
   ```
 
 </app-ctc-block>
 
 <!-- prettier-ignore-end -->
 
-From an HTML file, you can reference **node_modules** by starting the path with _node_modules_:
+The same can be done from an HTML file with a `<link>` tag:
 
 <!-- prettier-ignore-start -->
 
@@ -93,3 +96,12 @@ From an HTML file, you can reference **node_modules** by starting the path with 
 </app-ctc-block>
 
 <!-- prettier-ignore-end -->
+
+These conventions are also compatible with [**Import Attributes**](/docs/introduction/web-standards/#import-attributes) and CSS Module Scripts. For example, since [Spectrum Web Components](https://opensource.adobe.com/spectrum-web-components/) expose its CSS through an exports map, bare CSS specifiers also work in Greenwood.
+
+```js
+import SpectrumCard from "@spectrum-css/card" with { type: "css" };
+import SpectrumTokens from "@spectrum-css/tokens" with { type: "css" };
+
+console.log({ SpectrumCard, SpectrumTokens });
+```

--- a/src/pages/guides/ecosystem/index.md
+++ b/src/pages/guides/ecosystem/index.md
@@ -77,9 +77,9 @@ Or to use something CSS based like [**Open Props**](https://open-props.style), s
   ```html
   <html>
     <head>
-      <link ref="stylesheet" href="/node_modules/open-props/src/props.fonts.css" />
-      <link ref="stylesheet" href="/node_modules/open-props/src/props.shadows.css" />
-      <link ref="stylesheet" href="/node_modules/open-props/src/props.sizes.css" />
+      <link ref="stylesheet" href="/node_modules/open-props/fonts.min.css" />
+      <link ref="stylesheet" href="/node_modules/open-props/shadows.min.css" />
+      <link ref="stylesheet" href="/node_modules/open-props/sizes.min.css" />
 
       <style>
         h1 {

--- a/src/pages/guides/ecosystem/lit.md
+++ b/src/pages/guides/ecosystem/lit.md
@@ -9,7 +9,7 @@ tocHeading: 2
 
 [**Lit**](https://lit.dev/) builds on top of the Web Components standards, adding additional developer experience ergonomics like reactivity, declarative templates and reducing boilerplate. Lit also has support for SSR (server-side rendering), which Greenwood supports through a plugin.
 
-> You can see a complete hybrid project example in this [demonstration repo](https://github.com/thescientist13/greenwood-lit-ssr).
+> You can see a complete hybrid project example in this [demonstration repo](https://github.com/thescientist13/greenwood-lit-ssr) as well as [demos](https://github.com/thescientist13/greenwood-lit-ssr/pulls?q=is%3Apr+is%3Aopen+label%3Ademo) of using Lit based component libraries like [**Shoelace**](https://shoelace.style/) and [**Spectrum Web Components**](https://opensource.adobe.com/spectrum-web-components/) with Greenwood.
 
 ## Installation
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

resolves #144 

## Summary of Changes

1. Update docs around Import Maps implementation details and ecosystem compatibility
1. Improve Script and Styles docs for best practices regarding using bare and relative specifiers and the "shortcut" alias for referencing `/node_modules` based paths
1. Add Lit component library demos link to the Lit ecosystem page
1. Demonstrate helper utilities in Copy Plugin docs

## TODO
1. [x] Plugins Docs
1. [x] Typo - https://github.com/ProjectEvergreen/www.greenwoodjs.dev/pull/153/files#r1890986368
1. [x] Fix open props example in guides too - https://github.com/ProjectEvergreen/www.greenwoodjs.dev/blob/main/src/pages/guides/ecosystem/index.md
1. [x] Final draft review
    - make sure shortcut alias is documented as _not_ being an option for ESM (at least for SSR?)
    - https://github.com/ProjectEvergreen/www.greenwoodjs.dev/pull/153/files#r1910635364
    - https://github.com/ProjectEvergreen/www.greenwoodjs.dev/pull/153/files#r1919461371
1. [x] Create a discussion for Greenwood on imports - https://github.com/ProjectEvergreen/greenwood/discussions/1396
    - most `ERR_MODULE_NOT_FOUND` are related to typescript files.  Any way we can see those project's have a _package.json_ with just a `types` field (and none of our supported conditions) and suppress the error, since we can assume it's just a types file?
1. [x] call out ESM needed for import maps?
1. [x] has to merged _after_ and updated for snippets added in this PR - https://github.com/ProjectEvergreen/www.greenwoodjs.dev/pull/120