### PR TITLE
docs/issue 156 update markdown configuration docs and deprecate settings option

### DIFF
--- a/src/pages/docs/reference/configuration.md
+++ b/src/pages/docs/reference/configuration.md
@@ -24,7 +24,6 @@ export default {
   layoutsDirectory: "layouts", // e.g. ./src/layouts
   markdown: {
     plugins: [],
-    settings: {},
   },
   optimization: "default",
   pagesDirectory: "pages", // e.g. ./src/pages
@@ -208,9 +207,9 @@ By default the directory Greenwood will use to look for your layouts is in _layo
 
 ## Markdown
 
-You can install and provide custom **unifiedjs** [presets](https://github.com/unifiedjs/unified#preset) and [plugins](https://github.com/unifiedjs/unified#plugin) to further customize and process [your markdown](/docs/resources/markdown/) past what Greenwood does by default.
+You can install [**remark**](https://remark.js.org/) or [**rehype**](https://github.com/rehypejs/rehype) compatible plugins to extend Greenwood's markdown rendering and transformation capabilities by passing them as an array to the `markdown` setting.
 
-For plugins, after installing their packages, you can provide their names to Greenwood:
+After installing the package, pass the plugin name as a string:
 
 <!-- prettier-ignore-start -->
 
@@ -219,8 +218,7 @@ For plugins, after installing their packages, you can provide their names to Gre
   ```js
   export default {
     markdown: {
-      settings: { commonmark: true },
-      plugins: ["rehype-slug", "rehype-autolink-headings"],
+      plugins: ["rehype-slug", "remark-gfm"],
     },
   };
   ```

--- a/src/pages/docs/resources/markdown.md
+++ b/src/pages/docs/resources/markdown.md
@@ -10,7 +10,7 @@ In this section we'll cover some of the Markdown related feature of **Greenwood*
 
 ## Plugins
 
-Using your _greenwood.config.js_ you can have additional [markdown customizations and configurations](/docs/reference/configuration/#markdown) using unified presets and plugins.
+Using your _greenwood.config.js_ you can have additional [markdown customizations and configurations](/docs/reference/configuration/#markdown).
 
 For example, to use the [**remark-github**](https://github.com/remarkjs/remark-github) plugin:
 
@@ -22,9 +22,6 @@ For example, to use the [**remark-github**](https://github.com/remarkjs/remark-g
   // npm i -D remark-github
   export default {
     markdown: {
-      settings: {
-        /* whatever you need */
-      },
       plugins: ["remark-github"],
     },
   };


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

resolves #156 

## Summary of Changes

1. Remove reference to markdown settings configuration
1. Refresh docs / links / usage

## TODO
1. [x] has to merged _after_ - https://github.com/ProjectEvergreen/www.greenwoodjs.dev/pull/120