### PR TITLE
docs/document new minimum NodeJS LTS version requirements

### DIFF
--- a/src/pages/docs/introduction/setup.md
+++ b/src/pages/docs/introduction/setup.md
@@ -10,7 +10,7 @@ Greenwood has a few options for getting a new project started. You can also chec
 
 ## Init
 
-The recommended way to start a new Greenwood project, our **init** CLI will scaffold out a starter project for you. Just run a single command and then follow the prompts.
+The recommended way to start a new Greenwood project, our **init** CLI will scaffold out a starter project for you. Just run a single command and then follow the prompts. Make sure you have the [latest LTS version of Node](https://nodejs.org/en/download) installed.
 
 To scaffold into the _current_ directory, run:
 

--- a/src/pages/docs/pages/server-rendering.md
+++ b/src/pages/docs/pages/server-rendering.md
@@ -302,24 +302,42 @@ For request handling, Greenwood will pass a native `Request` object and a Greenw
 
 ## Custom Imports
 
-To use custom imports on the server side for prerendering or SSR use cases (ex. CSS, JSON), you will need to invoke Greenwood using **NodeJS** from the CLI and pass it the `--loaders` flag along with the path to Greenwood's provided loader function.
+To use custom imports (non JavaScript resources) on the server side for prerendering or SSR use cases, you will need to invoke Greenwood using **NodeJS** from the CLI and pass the `--imports` flag along with the path to Greenwood's provided register function. _**This feature requires NodeJS version `>=21.10.0`**_.
 
 <!-- prettier-ignore-start -->
-<app-ctc-block variant="shell" paste-contents="node --loader ./node_modules/@greenwood/cli/src/loader.js ./node_modules/@greenwood/cli/src/index.js <command>">
+
+<app-ctc-block variant="shell" paste-contents="node --import @greenwood/cli/register ./node_modules/@greenwood/cli/src/index.js <command>">
 
   ```shell
-  $ node --loader ./node_modules/@greenwood/cli/src/loader.js ./node_modules/@greenwood/cli/src/index.js <command>
+  $ node --import @greenwood/cli/register ./node_modules/@greenwood/cli/src/index.js <command>
   ```
 
 </app-ctc-block>
 
 <!-- prettier-ignore-end -->
 
-Then you will be able to run this, or for any custom format you want using a plugin.
+Or most commonly as an npm script in your _package.json_
+
+<!-- prettier-ignore-start -->
+
+<app-ctc-block variant="snippet" heading="package.json">
+
+  ```json
+  {
+    "scripts": {
+      "build": "node --import @greenwood/cli/register ./node_modules/@greenwood/cli/src/index.js build"
+    }
+  }
+```
+
+</app-ctc-block>
+
+<!-- prettier-ignore-end -->
+
+Now any custom resource plugins will operate on the server side, enabling compatibility with non-JavaScript resources not supported by NodeJS, like CSS Module Scripts.
 
 ```js
 import sheet from "./styles.css" with { type: "css" };
-import data from "./data.json" with { type: "json" };
 
-console.log({ sheet, data });
+console.log({ sheet });
 ```

--- a/src/pages/guides/getting-started/index.md
+++ b/src/pages/guides/getting-started/index.md
@@ -20,17 +20,14 @@ This _Getting Started_ guide will walk you through creating a basic static conte
 
 You will need the following installed on your machine:
 
-1. [**NodeJS LTS**](https://nodejs.org/en/download/package-manager) (required) - We recommend using a Node version manager (like NVM) to install the latest stable version of Node
+1. [**NodeJS LTS**](https://nodejs.org/en/download) (required) - We recommend using a Node version manager (like NVM) to install the latest stable version of Node
 1. [**Git**](https://git-scm.com/) (optional) - Can be useful for [cloning and inspecting](https://github.com/ProjectEvergreen/greenwood-getting-started) the companion repo for this guide, or otherwise managing your Greenwood project through version control
 
-You can verify that both NodeJS and NPM are installed correctly by checking their version from the command line:
+You can verify that NodeJS has been installed correctly by checking its version from the command line:
 
 ```bash
 $ node -v
-v18.12.1
-
-$ npm -v
-8.19.2
+v22.13.0
 ```
 
 ## Setup

--- a/src/pages/guides/hosting/aws.md
+++ b/src/pages/guides/hosting/aws.md
@@ -82,32 +82,32 @@ If you're using GitHub, you can use GitHub Actions to automate the pushing of bu
       build:
         runs-on: ubuntu-latest
 
-      # match to your version of NodeJS
-      steps:
-        - uses: actions/checkout@v4
-        - uses: actions/setup-node@v4
-          with:
-            node-version: 22
+        # match to your version of NodeJS
+        steps:
+          - uses: actions/checkout@v4
+          - uses: actions/setup-node@v4
+            with:
+              node-version: 22
 
-      - name: Install Dependencies
-        run: |
-          npm ci
+        - name: Install Dependencies
+          run: |
+            npm ci
 
-      # use your greenwood build script
-      - name: Run Build
-        run: |
-          npm run build
+        # use your greenwood build script
+        - name: Run Build
+          run: |
+            npm run build
 
-      - name: Upload to S3 and invalidate CDN
-        uses: opspresso/action-s3-sync@master
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_SECRET_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          # make sure this matches your bucket's region
-          AWS_REGION: "us-east-1"
-          FROM_PATH: "./public"
-          # your target s3 bucket name goes here
-          DEST_PATH: s3://${{ secrets.AWS_BUCKET_NAME }}
+        - name: Upload to S3 and invalidate CDN
+          uses: opspresso/action-s3-sync@master
+          env:
+            AWS_ACCESS_KEY_ID: ${{ secrets.AWS_SECRET_ACCESS_KEY_ID }}
+            AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+            # make sure this matches your bucket's region
+            AWS_REGION: "us-east-1"
+            FROM_PATH: "./public"
+            # your target s3 bucket name goes here
+            DEST_PATH: s3://${{ secrets.AWS_BUCKET_NAME }}
     ```
 
   </app-ctc-block>

--- a/src/pages/guides/hosting/aws.md
+++ b/src/pages/guides/hosting/aws.md
@@ -67,7 +67,7 @@ If you're using GitHub, you can use GitHub Actions to automate the pushing of bu
 1. At the root of your repo add a GitHub Action called _.github/workflows/publish.yml_ and adapt as needed for your own branch, build commands, and package manager.
 
   <!-- prettier-ignore-start -->
-  
+
   <app-ctc-block variant="snippet" heading=".github/workflows/publish.yml">
 
     ```yml
@@ -82,32 +82,32 @@ If you're using GitHub, you can use GitHub Actions to automate the pushing of bu
       build:
         runs-on: ubuntu-latest
 
-       # match to your version of NodeJS
-       steps:
-         - uses: actions/checkout@v4
-         - uses: actions/setup-node@v4
-           with:
-             node-version: 22
+      # match to your version of NodeJS
+      steps:
+        - uses: actions/checkout@v4
+        - uses: actions/setup-node@v4
+          with:
+            node-version: 22
 
-        - name: Install Dependencies
-          run: |
-            npm ci
+      - name: Install Dependencies
+        run: |
+          npm ci
 
-        # use your greenwood build script
-        - name: Run Build
-          run: |
-            npm run build
+      # use your greenwood build script
+      - name: Run Build
+        run: |
+          npm run build
 
-        - name: Upload to S3 and invalidate CDN
-          uses: opspresso/action-s3-sync@master
-          env:
-            AWS_ACCESS_KEY_ID: ${{ secrets.AWS_SECRET_ACCESS_KEY_ID }}
-            AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-            # make sure this matches your bucket's region
-            AWS_REGION: "us-east-1"
-            FROM_PATH: "./public"
-            # your target s3 bucket name goes here
-            DEST_PATH: s3://${{ secrets.AWS_BUCKET_NAME }}
+      - name: Upload to S3 and invalidate CDN
+        uses: opspresso/action-s3-sync@master
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_SECRET_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          # make sure this matches your bucket's region
+          AWS_REGION: "us-east-1"
+          FROM_PATH: "./public"
+          # your target s3 bucket name goes here
+          DEST_PATH: s3://${{ secrets.AWS_BUCKET_NAME }}
     ```
 
   </app-ctc-block>

--- a/src/pages/guides/hosting/aws.md
+++ b/src/pages/guides/hosting/aws.md
@@ -89,25 +89,25 @@ If you're using GitHub, you can use GitHub Actions to automate the pushing of bu
             with:
               node-version: 22
 
-        - name: Install Dependencies
-          run: |
-            npm ci
+          - name: Install Dependencies
+            run: |
+              npm ci
 
-        # use your greenwood build script
-        - name: Run Build
-          run: |
-            npm run build
+          # use your greenwood build script
+          - name: Run Build
+            run: |
+              npm run build
 
-        - name: Upload to S3 and invalidate CDN
-          uses: opspresso/action-s3-sync@master
-          env:
-            AWS_ACCESS_KEY_ID: ${{ secrets.AWS_SECRET_ACCESS_KEY_ID }}
-            AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-            # make sure this matches your bucket's region
-            AWS_REGION: "us-east-1"
-            FROM_PATH: "./public"
-            # your target s3 bucket name goes here
-            DEST_PATH: s3://${{ secrets.AWS_BUCKET_NAME }}
+          - name: Upload to S3 and invalidate CDN
+            uses: opspresso/action-s3-sync@master
+            env:
+              AWS_ACCESS_KEY_ID: ${{ secrets.AWS_SECRET_ACCESS_KEY_ID }}
+              AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+              # make sure this matches your bucket's region
+              AWS_REGION: "us-east-1"
+              FROM_PATH: "./public"
+              # your target s3 bucket name goes here
+              DEST_PATH: s3://${{ secrets.AWS_BUCKET_NAME }}
     ```
 
   </app-ctc-block>

--- a/src/pages/guides/hosting/aws.md
+++ b/src/pages/guides/hosting/aws.md
@@ -67,6 +67,7 @@ If you're using GitHub, you can use GitHub Actions to automate the pushing of bu
 1. At the root of your repo add a GitHub Action called _.github/workflows/publish.yml_ and adapt as needed for your own branch, build commands, and package manager.
 
   <!-- prettier-ignore-start -->
+  
   <app-ctc-block variant="snippet" heading=".github/workflows/publish.yml">
 
     ```yml
@@ -79,34 +80,34 @@ If you're using GitHub, you can use GitHub Actions to automate the pushing of bu
 
     jobs:
       build:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
 
-        # match to your version of NodeJS
-        steps:
-          - uses: actions/checkout@v2
-          - uses: actions/setup-node@v3
-            with:
-              node-version: 18.20.2
+       # match to your version of NodeJS
+       steps:
+         - uses: actions/checkout@v4
+         - uses: actions/setup-node@v4
+           with:
+             node-version: 22
 
-          - name: Install Dependencies
-            run: |
-              npm ci
+        - name: Install Dependencies
+          run: |
+            npm ci
 
-          # use your greenwood build script
-          - name: Run Build
-            run: |
-              npm run build
+        # use your greenwood build script
+        - name: Run Build
+          run: |
+            npm run build
 
-          - name: Upload to S3 and invalidate CDN
-            uses: opspresso/action-s3-sync@master
-            env:
-              AWS_ACCESS_KEY_ID: ${{ secrets.AWS_SECRET_ACCESS_KEY_ID }}
-              AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-              # make sure this matches your bucket's region
-              AWS_REGION: "us-east-1"
-              FROM_PATH: "./public"
-              # your target s3 bucket name goes here
-              DEST_PATH: s3://${{ secrets.AWS_BUCKET_NAME }}
+        - name: Upload to S3 and invalidate CDN
+          uses: opspresso/action-s3-sync@master
+          env:
+            AWS_ACCESS_KEY_ID: ${{ secrets.AWS_SECRET_ACCESS_KEY_ID }}
+            AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+            # make sure this matches your bucket's region
+            AWS_REGION: "us-east-1"
+            FROM_PATH: "./public"
+            # your target s3 bucket name goes here
+            DEST_PATH: s3://${{ secrets.AWS_BUCKET_NAME }}
     ```
 
   </app-ctc-block>

--- a/src/pages/guides/hosting/github.md
+++ b/src/pages/guides/hosting/github.md
@@ -67,14 +67,14 @@ Following the steps [outlined here](https://pages.github.com/), first make sure 
 
     jobs:
       build-and-deploy:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
 
         # match to your version of NodeJS
         steps:
-          - uses: actions/checkout@v2
-          - uses: actions/setup-node@v3
+          - uses: actions/checkout@v4
+          - uses: actions/setup-node@v4
             with:
-              node-version: 18.20.2
+              node-version: 22
 
           # or replace with yarn, pnpm, etc
           - name: Install Dependencies

--- a/src/pages/guides/hosting/netlify.md
+++ b/src/pages/guides/hosting/netlify.md
@@ -27,7 +27,7 @@ For static hosting, nothing is needed other than connecting your repository and 
     skip_processing = true
 
   [build.environment]
-    NODE_VERSION = "18.x"
+    NODE_VERSION = "22.x"
   ```
 
 </app-ctc-block>


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

resolves #158 

## Summary of Changes

1. Document new `register` API for NodeJS custom loaders
1. Document the new minimum version needed

## TODO
1. [x] Confirm correct minimum version - https://github.com/ProjectEvergreen/www.greenwoodjs.dev/pull/159/files#r1908044410
    - Yes, because we have to account for JSON Import Attributes as well - https://github.com/ProjectEvergreen/greenwood/issues/1202#issuecomment-2566656021
1. [x] Should call out compatibility with all current LTS Node versions - https://github.com/ProjectEvergreen/greenwood/pull/1372
1. [x] check adapter /hosting examples, e.g. `18.x`
1. [x] has to merged _after_ and updated for snippets added in this PR - https://github.com/ProjectEvergreen/www.greenwoodjs.dev/pull/120