### PR TITLE
docs/clarify SSR body and layout APIs

### DIFF
--- a/src/pages/docs/pages/layouts.md
+++ b/src/pages/docs/pages/layouts.md
@@ -120,4 +120,4 @@ export default class AppLayout extends HTMLElement {
 }
 ```
 
-> ⚠ This function is _only run once at build time_. Dynamic "runtime" layouts are [planned](https://github.com/ProjectEvergreen/greenwood/issues/1248).
+> ⚠ This layout component will _only run once at build time_. Dynamic "runtime" layouts are [planned](https://github.com/ProjectEvergreen/greenwood/issues/1248).

--- a/src/pages/docs/pages/layouts.md
+++ b/src/pages/docs/pages/layouts.md
@@ -91,3 +91,33 @@ As with Page layouts, App layouts are just HTML:
 ```
 
 > When an app layout is present, Greenwood will merge the `<head>` and `<body>` tags for both app and page layouts into one HTML document structure for you.
+
+## Server Rendering
+
+Server rendered layouts can also be authored using Web Components:
+
+```js
+// src/layouts/app.js
+export default class AppLayout extends HTMLElement {
+  async connectedCallback() {
+    const year = new Date().getFullYear();
+
+    this.innerHTML = `
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <title>My App</title>
+        </head>
+
+        <body>
+          <h1>My App</h1>
+          <page-outlet></page-outlet>
+          <footer>&copy; ${year}</footer>
+        </body>
+      </html>
+    `;
+  }
+}
+```
+
+> ⚠ This function is _only run once at build time_. Dynamic "runtime" layouts are [planned](https://github.com/ProjectEvergreen/greenwood/issues/1248).

--- a/src/pages/docs/pages/server-rendering.md
+++ b/src/pages/docs/pages/server-rendering.md
@@ -20,9 +20,9 @@ The above would serve content in a browser at the path _/users/_.
 
 ## Usage
 
-In your page file, Greenwood supports the following functions that you can `export` for providing server rendered content and [frontmatter](/docs/resources/markdown/):
+In your page file, Greenwood supports the following functions that you can `export` for providing server rendered content and [frontmatter](/docs/resources/markdown/) to produce the `<body><body>` content for your page.
 
-- **default** (recommended): Use the custom elements API to render out your page content, aka **Web (Server) Components**
+- **default** (recommended): Use the custom elements API to render out your page content, aka **Web (Server) Components**. _This will take precedence over `getBody`_ and will also automatically track your custom element dependencies (in place of having to define frontmatter imports in `getFrontmatter`).
 - **getBody**: Return a string of HTML for the contents of the page
 - **getLayout**: Return a string of HTML to act as the [page's layout](/docs/pages/layouts/#pages)
 - **getFrontmatter**: Provide an object of [frontmatter](/docs/resources/markdown/#frontmatter) properties. Useful in conjunction with [content as data](/docs/content-as-data/), or otherwise setting static configuration / metadata through SSR.
@@ -81,7 +81,12 @@ export default class UsersPage extends HTMLElement {
       })
       .join("");
 
-    this.innerHTML = html;
+    this.innerHTML = `
+      <body>
+        <h1>Friends List</h1>
+        ${html}
+      </body>
+    `;
   }
 }
 ```
@@ -134,7 +139,7 @@ export async function getBody(compilation, page, request) {
 
 ### Layouts
 
-For creating a [layout](/docs/pages/layouts/) dynamically, you can provide a `getLayout` function and return the HTML you need.
+Although global [layouts](/docs/pages/layouts/) exist, you can provide a `getLayout` function on a per page basis to override or set the layout for the given page.
 
 You can pull in data from Greenwood's [compilation](/docs/reference/appendix/#compilation) object as well as the specific route:
 
@@ -164,6 +169,8 @@ export async function getLayout(compilation, route) {
   `;
 }
 ```
+
+> ⚠ This function is _only run once at build time_. Dynamic "runtime" layouts are [planned](https://github.com/ProjectEvergreen/greenwood/issues/1248).
 
 ### Frontmatter
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

Got some feedback in Discord that some of the docs around SSR pages and layouts wasn't clear in certain areas.  For example, in the case of SSR pages, it was not clear the relationship between [`default export` and `getBody` APIs](https://greenwoodjs.dev/docs/pages/server-rendering/), which used to be a bit clearer on the old website
![Screenshot 2025-01-21 at 7 48 12 PM](https://github.com/user-attachments/assets/1b4759b4-6726-42d3-b879-f37f4f344841)

## Summary of Changes

1. Clarify relationship between `default export` and `getBody` SSR page APIs
1. Realized there wasn't an example of a basic dynamic layout

## TODO
1. [x] Confirm support of custom resources for layouts (e.g. TypeScript, _src/pages/app.ts_) like we do for SSR pages and API routes - https://github.com/ProjectEvergreen/greenwood/tree/master/packages/plugin-typescript#pages - https://github.com/ProjectEvergreen/greenwood/issues/1395
1. [x] confirm / clarify expectations around frontmatter layouts mapping - https://github.com/ProjectEvergreen/greenwood/issues/1248#issuecomment-2607893551