### PR TITLE
bug/issue 168 restore original drop shadow styles

### DIFF
--- a/src/components/hero-banner/hero-banner.module.css
+++ b/src/components/hero-banner/hero-banner.module.css
@@ -50,7 +50,7 @@
   background-color: var(--color-primary);
   width: 100%;
   color: var(--color-white) !important;
-  box-shadow: var(--shadow-4);
+  box-shadow: var(--shadow-3);
   margin-top: var(--size-fluid-1);
   height: fit-content;
   text-decoration: none;
@@ -77,7 +77,7 @@
 .snippet {
   border-radius: var(--radius-4);
   border: var(--radius-1) solid #c1d3cd;
-  box-shadow: var(--shadow-4);
+  box-shadow: var(--shadow-2);
   margin: var(--size-px-2) 0;
   text-align: center;
   padding: var(--size-1);
@@ -86,9 +86,9 @@
 
 .snippet pre {
   font-size: 16px;
-  height: 46px;
+  height: 50px;
   align-content: center;
-  display: inline;
+  display: inline-block;
   background-color: transparent;
   color: var(--color-black);
   vertical-align: middle;
@@ -134,6 +134,7 @@
   .snippet pre {
     padding: 0 10px;
     vertical-align: text-top;
+    display: inline;
   }
 
   .snippet app-ctc-button {

--- a/src/components/latest-post/latest-post.module.css
+++ b/src/components/latest-post/latest-post.module.css
@@ -3,7 +3,7 @@
   border-radius: var(--radius-4);
   padding: var(--size-2);
   border: var(--radius-1) solid var(--color-gray-background);
-  box-shadow: var(--shadow-2);
+  box-shadow: var(--shadow-1);
   text-align: left;
 
   & .new {

--- a/src/components/run-anywhere/run-anywhere.module.css
+++ b/src/components/run-anywhere/run-anywhere.module.css
@@ -33,7 +33,7 @@
 .iconBox {
   border-radius: var(--radius-3);
   border: 1px solid var(--color-gray-background);
-  box-shadow: var(--shadow-2);
+  box-shadow: var(--shadow-1);
   background-color: var(--color-white);
   height: 150px;
   align-content: center;

--- a/src/components/side-nav/side-nav.module.css
+++ b/src/components/side-nav/side-nav.module.css
@@ -26,7 +26,7 @@
   border: none;
   padding: var(--size-2);
   border-radius: var(--radius-2);
-  box-shadow: var(--shadow-3);
+  box-shadow: var(--shadow-1);
   color: var(--color-black);
 
   @media (prefers-reduced-motion: no-preference) {

--- a/src/components/table-of-contents/table-of-contents.module.css
+++ b/src/components/table-of-contents/table-of-contents.module.css
@@ -26,7 +26,7 @@
   min-height: 250px;
   margin: 0 var(--size-2);
   border: 1px solid var(--color-gray);
-  box-shadow: var(--shadow-4);
+  box-shadow: var(--shadow-3);
   padding: var(--size-2);
 }
 
@@ -36,7 +36,7 @@
   border: none;
   padding: var(--size-2);
   border-radius: var(--radius-2);
-  box-shadow: var(--shadow-3);
+  box-shadow: var(--shadow-2);
 
   @media (prefers-reduced-motion: no-preference) {
     & #indicator {


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

resolves #168 

## Summary of Changes

1. Last Post
1. `npx init` CTA (and made a little taller for mobile)
1. Side Nav active link
1. Table of Contents  (w/ staggered styles for mobile)

![Screenshot 2025-01-27 at 10 27 51 PM](https://github.com/user-attachments/assets/7b7552ee-35fe-4024-88d5-cad8dd70e0be)

![Screenshot 2025-01-27 at 10 28 26 PM](https://github.com/user-attachments/assets/3e7a2694-2a3d-4deb-9791-ecd3f11603b0)

![Screenshot 2025-01-27 at 10 27 08 PM](https://github.com/user-attachments/assets/11e79343-7778-4083-bec6-f3e034535aa9)

![Screenshot 2025-01-27 at 10 27 27 PM](https://github.com/user-attachments/assets/af31744f-f0ab-4214-ac63-88b69344ad58)