### PR TITLE
enhancement/issue 96 icons positioning and alignment tweaks

### DIFF
--- a/src/components/copy-to-clipboard-block/ctc-block.css
+++ b/src/components/copy-to-clipboard-block/ctc-block.css
@@ -12,7 +12,7 @@
     float: left;
     cursor: pointer;
     width: var(--size-fluid-5);
-    margin: var(--size-4) var(--size-2) var(--size-1) var(--size-2);
+    margin: var(--size-3) var(--size-1) var(--size-1) var(--size-1);
     border-bottom: 2px solid transparent;
     padding: var(--size-1);
     display: flex;
@@ -96,6 +96,7 @@
 
   & pre {
     border: 2px solid var(--color-white);
+    margin: var(--size-3) 0 var(--size-2) 0;
   }
 
   & .copy-icon {

--- a/src/components/copy-to-clipboard-block/ctc-block.js
+++ b/src/components/copy-to-clipboard-block/ctc-block.js
@@ -9,8 +9,8 @@ const template = document.createElement("template");
 
 const scriptRunnerLogoMapper = {
   npm: npmLogo,
-  yarn: yarnLogo,
   pnpm: pnpmLogo,
+  yarn: yarnLogo,
 };
 
 export default class CopyToClipboardBlock extends HTMLElement {


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

related to #96 

Noticed a couple issues with icon alignments / positioning

1. Runner icons horizontal alignment looks off / not well centered
    <img width="910" alt="Screenshot 2025-01-28 at 1 09 16 PM" src="https://github.com/user-attachments/assets/f587408d-bd49-4169-a48e-de5fc325382b" />
1. Runner icons on mobile breaking onto two lines
    <img width="482" alt="Screenshot 2025-01-28 at 1 10 46 PM" src="https://github.com/user-attachments/assets/e5b76c14-ab93-4e07-bfb1-61c7d17b0f47" />
1. Shell copy icon to too cramped
    <img width="428" alt="Screenshot 2025-01-28 at 1 27 26 PM" src="https://github.com/user-attachments/assets/9c5ef400-8c02-4553-baa9-83ab4c7ecdc6" />

## Summary of Changes

1. Runner icons horizontal alignment looks off / not well centered (just switched the order 🧠 )
    <img width="911" alt="Screenshot 2025-01-28 at 1 36 49 PM" src="https://github.com/user-attachments/assets/ad70fc00-df1b-4242-967a-5bec9cf2a3ec" />
1. Runner icons on mobile breaking onto two lines
    <img width="497" alt="Screenshot 2025-01-28 at 1 36 16 PM" src="https://github.com/user-attachments/assets/e0a6815e-32ed-4d86-83c5-2dbc57d1c528" />
1. Shell copy icon to too cramped
    <img width="462" alt="Screenshot 2025-01-28 at 1 37 12 PM" src="https://github.com/user-attachments/assets/7af2c0a1-200a-4cf0-9027-d6a65362ad86" />