### PR TITLE
chore/new GitHub issue templates format

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,0 @@
-## Summary
-
-<!-- Brief summary of the issue, like steps to reproduce for a bug, screenshots, etc. If you are looking to make a feature request to Greenwood, please go to https://github.com/ProjectEvergreen/greenwood . -->
-
-## Details
-
-<!-- Please provide additional details that would be helpful to the team when reviewing this issue. -->

--- a/.github/ISSUE_TEMPLATE/1-documentation.yml
+++ b/.github/ISSUE_TEMPLATE/1-documentation.yml
@@ -1,0 +1,32 @@
+name: 📚 Documentation and Guides
+description: Documentation or Guide's related content.
+title: "Document feature x of Greenwood..."
+labels: ["docs", "guides"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping out to improve the Greenwood website!
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Please provide a summary of the documentation changes needed.
+      placeholder: Need to document new feature x added in the latest version of Greenwood.
+    validations:
+      required: true
+  - type: textarea
+    id: additional-details
+    attributes:
+      label: Additional Details
+      description: Please provide any additional details, links, code snippets, or resources that may provide useful context.
+    validations:
+      required: false
+  - type: input
+    id: greenwood-issue
+    attributes:
+      label: Greenwood Issue
+      description: A link to a relevant Greenwood GitHub issue.
+      placeholder: ex. https://github.com/ProjectEvergreen/greenwood/1111
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/2-content.yml
+++ b/.github/ISSUE_TEMPLATE/2-content.yml
@@ -1,0 +1,24 @@
+name: ✍️ Content
+description: Submit a new blog post or content related change to the website.
+title: "Blog post about..."
+labels: ["content"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping out to improve the Greenwood website!
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Please provide a summary of the content changes desired.
+      placeholder: Need to write a blog post about the latest version of Greenwood.
+    validations:
+      required: true
+  - type: textarea
+    id: additional-details
+    attributes:
+      label: Additional Details
+      description: Please provide any additional details, outline, or links to be considered.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/3-enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/3-enhancement.yml
@@ -1,0 +1,24 @@
+name: ✨ Enhancement
+description: New features or enhancements to the website itself.
+title: "Add light / dark mode toggle"
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping out to improve the Greenwood website!
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Please provide a summary of the current state of the website and what you would like updated about it.
+      placeholder: The website should have...
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Please provide any additional details, links, or resources that may be helpful for consideration of this enhancement.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/4-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/4-bug-report.yml
@@ -1,0 +1,43 @@
+name: 🐛 Bug
+description: Something isn't working with the website.
+title: "The social links in the header are broken"
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping out to improve the Greenwood website!
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Please provide a summary of the issue or error you are seeing, including error messages and screenshots
+      placeholder: Tell us what you see!
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction-steps
+    attributes:
+      label: Steps to reproduce
+      description: Please provide a set of steps to reproduce the issue.
+      placeholder: |
+        1. I went to the home page
+        2. I clicked on ...
+        3. etc
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Please provide details of the environment you're running in.
+      placeholder: Browser, operating system, etc
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Please provide any additional relevant details, screenshots, links, or resources that would be helpful.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/5-chore.yml
+++ b/.github/ISSUE_TEMPLATE/5-chore.yml
@@ -1,0 +1,17 @@
+name: ⚙️ Chore
+description: Technical tasks not related to Greenwood
+title: "Update repo configuration, maintaining dependencies, etc"
+labels: ["chore"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping out to improve the Greenwood website!
+  - type: textarea
+    id: task
+    attributes:
+      label: Task
+      description: Description of the task at hand
+      placeholder: Update ESLint config, change test runner, hosting, etc...
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,12 @@
+blank_issues_enabled: false
+
+contact_links:
+  - name: GitHub Discussions
+    url: https://github.com/ProjectEvergreen/greenwood/discussions
+    about: Have ideas or questions for the website, or creating showcases and templates for Greenwood? Start a conversation!
+  - name: Discord
+    url: https://www.greenwoodjs.dev/discord/
+    about: Chat about Greenwood and join the community!
+  - name: Greenwood GitHub
+    url: https://github.com/ProjectEvergreen/greenwood
+    about: Visit the Greenwood repo if you have an issue or question about Greenwood itself.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # www.greenwoodjs.dev
 
 [![Netlify Status](https://api.netlify.com/api/v1/badges/c7837ab5-866a-4bdf-b538-5adbd17d2a20/deploy-status)](https://app.netlify.com/sites/super-tapioca-5987ce/deploys)
+[![Discord Chat](https://img.shields.io/badge/chat-discord-blue?style=flat&logo=discord)](https://www.greenwoodjs.dev/discord/)
 
 Documentation website for [**GreenwoodJS**](https://www.greenwoodjs.dev/), using GreenwoodJS for development, naturally. Site is hosted on Netlify.
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

GitHub is no longer supporting the old issue template format.   See https://github.com/ProjectEvergreen/greenwood/pull/1400 for reference

> You can preview this by hitting the Issue button at https://github.com/ProjectEvergreen/greenwood/issues

## Summary of Changes

1. Added new issue template forms for:
    - Documentation
    - Content
    - Enhancement
    - Bug
    - Chore
1. Added Discord badge to the README