### PR TITLE
flesh out use cases for Rollup plugin use cases

### DIFF
--- a/src/pages/docs/reference/plugins-api.md
+++ b/src/pages/docs/reference/plugins-api.md
@@ -710,7 +710,7 @@ Below is an example from [Greenwood's codebase](https://github.com/ProjectEvergr
 
 ## Rollup
 
-Though rare, there may be cases for tapping into the bundling process for Greenwood. If so, this plugin type allow users to tap into Greenwood's [**Rollup**](https://rollupjs.org/) configuration to provide any custom Rollup behaviors you may need.
+Though rare, there may be some cases for tapping into the bundling phase of Greenwood's build pipeline, like [externalizing dependencies](https://rollupjs.org/configuration-options/#external) (e.g. the AWS SDK) or [pre-fixing specifiers](https://docs.deno.com/runtime/fundamentals/node/) for certain runtimes (e.g. `npm:`, `node:`). For these kinds of use cases, this plugin type allow users to tap into Greenwood's [**Rollup**](https://rollupjs.org/) bundling configuration to provide any custom Rollup behaviors you may need.
 
 Simply use the `provider` method to return an array of Rollup plugins:
 
@@ -740,6 +740,8 @@ Simply use the `provider` method to return an array of Rollup plugins:
 </app-ctc-block>
 
 <!-- prettier-ignore-end -->
+
+> Reminder: this plugin type will only to production builds, and _not_ during development. Resource plugins are the best way to handle transformations for development and production.
 
 ## Server
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

As part of working on features like https://github.com/ProjectEvergreen/greenwood/issues/1142 and https://github.com/ProjectEvergreen/greenwood/issues/1322, it better helped contextualize this long-standing Discussion in the Greenwood repo around the value / "risk" of having a Rollup plugin type.

In hindsight, given very clear guidelines / recommendations / use cases, it can in fact be a very helpful option after all.

## Summary of Changes

1. Expand / clarify use cases for Rollup plugin type

## TODO
1. [ ] After this merged, we can probably go ahead and close out https://github.com/ProjectEvergreen/greenwood/discussions/550
