### PR TITLE
docs/issue 180 fixed a typo on the Body section of the server rendering documentation

### DIFF
--- a/src/pages/docs/pages/server-rendering.md
+++ b/src/pages/docs/pages/server-rendering.md
@@ -108,7 +108,7 @@ A couple of notes:
 
 ### Body
 
-To return just the body of the page, you can use the `getBody` API. You will get access the [compilation](/docs/reference/appendix/#compilation), page specific data, and the incoming request.
+To return just the body of the page, you can use the `getBody` API. You will get access to the [compilation](/docs/reference/appendix/#compilation), page specific data, and the incoming request.
 
 In this example, we return a list of users from an API as HTML:
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

resolves https://github.com/ProjectEvergreen/www.greenwoodjs.dev/issues/180

## Summary of Changes

1. [x] Fixed typo by adding 'to' to the second paragraph in the Body section of the server rendering page