### PR TITLE
guides/fix example heading for WTR and content as data snippet

### DIFF
--- a/src/pages/guides/ecosystem/web-test-runner.md
+++ b/src/pages/guides/ecosystem/web-test-runner.md
@@ -264,7 +264,7 @@ This can be done by overriding `window.fetch` and providing the desired response
 
 <!-- prettier-ignore-start -->
 
-<app-ctc-block variant="snippet" heading="web-test-runner.config.js">
+<app-ctc-block variant="snippet" heading="blog-posts-list.spec.js">
 
   ```js
   import { expect } from "@esm-bundle/chai";


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue


Noticed when trying to follow this example for [WTR <> Content as data](https://greenwoodjs.dev/guides/ecosystem/web-test-runner/#content-as-data) integration, and copying the `window.fetch` snippet, the code snippet heading implied this should go in _web-test-runner.config.js_
![Screenshot 2025-03-23 at 3 51 47 PM](https://github.com/user-attachments/assets/0d9478a9-e145-4329-b296-8112cb4c3204)

which leads to this error if you do
```sh
➜  www.owenascode.dev git:(feature/issue-10-header-component) ✗ npm run test

> www.owenascode.dev@1.0.0 test
> wtr

ReferenceError: window is not defined
    at file:///Users/owenbuckley/Workspace/github/www.owenascode.dev/web-test-runner.config.js:8:1
    at ModuleJob.run (node:internal/modules/esm/module_job:271:25)
    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:547:26)
    at async importConfig (/Users/owenbuckley/Workspace/github/www.owenascode.dev/node_modules/.pnpm/@web+config-loader@0.3.2/node_modules/@web/config-loader/src/importConfig.js:17:20)
    at async readFileConfig (/Users/owenbuckley/Workspace/github/www.owenascode.dev/node_modules/.pnpm/@web+test-runner@0.19.0/node_modules/@web/test-runner/dist/config/readFileConfig.js:13:16)
    at async startTestRunner (/Users/owenbuckley/Workspace/github/www.owenascode.dev/node_modules/.pnpm/@web+test-runner@0.19.0/node_modules/@web/test-runner/dist/startTestRunner.js:20:15)
```

Looking closer at the snippet, it becomes obvious the `window.fetch` snippet is supposed to go into the _test case_ file itself.

## Summary of Changes

1. Fixed the snippet heading to indicate this is for a test file (_not_ the WTR config file 😅 )
