### PR TITLE
content/fix punctuation in app meta description

### DIFF
--- a/src/layouts/app.html
+++ b/src/layouts/app.html
@@ -6,7 +6,7 @@
     <meta property="og:title" content="Greenwood" />
     <meta
       name="description"
-      content="Greenwood is your workbench for the web, embracing web standards from the ground up to empower your stack from front to back.."
+      content="Greenwood is your workbench for the web, embracing web standards from the ground up to empower your stack from front to back."
     />
     <meta name="twitter:site" content="@PrjEvergreen" />
     <meta property="og:type" content="website" />


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

N / A

## Summary of Changes

1. Remove extra period in app layout `<meta>` description