### PR TITLE
Adjust margin in sidebar to center elements

### DIFF
--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -133,6 +133,7 @@ h4:focus > a > span.icon {
 
 li {
   margin: var(--size-2) 0;
+  margin-left: 20%;
 }
 
 .page-content {


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
(https://github.com/ProjectEvergreen/www.greenwoodjs.dev/issues/184)
## Summary of Changes
Centred the ToC by adjusting the margin of the box so that it will no longer hug the left side of the box.
