### PR TITLE
bug/apply consistent why greenwood cards content height

### DIFF
--- a/src/components/why-greenwood/why-greenwood.module.css
+++ b/src/components/why-greenwood/why-greenwood.module.css
@@ -109,4 +109,14 @@
   .subHeading {
     width: 70%;
   }
+
+  .card {
+    height: 540px;
+  }
+}
+
+@media (min-width: 1600px) {
+  .card {
+    height: 440px;
+  }
 }


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

Noticed that at >= 1440px screen widths, the _"Why Greennwod?"_ card content heights were not the same

![Screenshot 2025-06-01 at 1 35 48 PM](https://github.com/user-attachments/assets/0a0e09ec-f63d-43af-b08c-06661756ed62)

## Summary of Changes

1. Remove addition card height styles at >= 1440px width

![Screenshot 2025-06-01 at 1 38 26 PM](https://github.com/user-attachments/assets/ee650591-7a5c-4c96-99a0-8b94161ca6f8)