### PR TITLE
docs: #219 updated recommend tsconfig.json settings

### DIFF
--- a/src/pages/docs/resources/typescript.md
+++ b/src/pages/docs/resources/typescript.md
@@ -21,9 +21,9 @@ The below steps will help you get up and running with TypeScript in your Greenwo
 1. Create a _tsconfig.json_ file at the root of your project with the below minimum configuration settings.
 1. We also recommend additional configurations like [`verbatimModuleSyntax`](https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax) and [`erasableSyntaxOnly` setting](https://www.typescriptlang.org/tsconfig/#erasableSyntaxOnly)
 
-  <!-- prettier-ignore-start -->
+<!-- prettier-ignore-start -->
 
-  <app-ctc-block variant="snippet" heading="tsconfig.json">
+<app-ctc-block variant="snippet" heading="tsconfig.json">
 
 ```json5
 {
@@ -45,9 +45,9 @@ The below steps will help you get up and running with TypeScript in your Greenwo
 }
 ```
 
-  </app-ctc-block>
+</app-ctc-block>
 
-  <!-- prettier-ignore-end -->
+<!-- prettier-ignore-end -->
 
 > _If you're feeling adventurous, you can use **>=23.x** and omit the `--experimental-strip-types` flag_. Keep an eye on [this PR](https://github.com/nodejs/node/pull/57298) for when unflagged type-stripping support may come to Node LTS **22.x**. 👀
 

--- a/src/pages/docs/resources/typescript.md
+++ b/src/pages/docs/resources/typescript.md
@@ -18,7 +18,7 @@ The below steps will help you get up and running with TypeScript in your Greenwo
 
 1. You will need to use Node **>= 22.6.0** and set the `--experimental-strip-types` flag
 1. Install TypeScript into your project, e.g. `npm i typescript --save-dev`
-1. Create a _tsconfig.json_ file at the root of your project with these minimum configuration settings. We recommend adding the [`erasableSyntaxOnly` setting](https://www.typescriptlang.org/tsconfig/#erasableSyntaxOnly)
+1. Create a _tsconfig.json_ file at the root of your project with these minimum configuration settings. We also recommend adding the [`erasableSyntaxOnly` setting](https://www.typescriptlang.org/tsconfig/#erasableSyntaxOnly)
 
   <!-- prettier-ignore-start -->
 
@@ -27,6 +27,7 @@ The below steps will help you get up and running with TypeScript in your Greenwo
 ```json
 {
   "compilerOptions": {
+    "target": "es2015",
     "module": "preserve",
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,

--- a/src/pages/docs/resources/typescript.md
+++ b/src/pages/docs/resources/typescript.md
@@ -29,7 +29,7 @@ The below steps will help you get up and running with TypeScript in your Greenwo
   {
     "compilerOptions": {
       // minimum required configuration
-      "target": "es2020",
+      "target": "es2020", // needs to be at least >= es2015 for `class` support
       "module": "preserve",
       "moduleResolution": "bundler",
       "allowImportingTsExtensions": true,
@@ -74,6 +74,8 @@ In addition to being able to author your components, SSR pages, and API routes i
 </app-ctc-block>
 
 <!-- prettier-ignore-end -->
+
+> We recommend putting the `type` on the outside of the braces to avoid [inadvertent bundling](https://github.com/ProjectEvergreen/greenwood/issues/1576) of the package your importing from.
 
 See our [reference docs on Greenwood's available types](/docs/reference/appendix/#types) for more information on authoring with TypeScript.
 

--- a/src/pages/docs/resources/typescript.md
+++ b/src/pages/docs/resources/typescript.md
@@ -27,21 +27,21 @@ The below steps will help you get up and running with TypeScript in your Greenwo
 
   ```json5
   {
-    compilerOptions: {
+    "compilerOptions": {
       // minimum required configuration
-      target: "es2020",
-      module: "preserve",
-      moduleResolution: "bundler",
-      allowImportingTsExtensions: true,
-      noEmit: true,
+      "target": "es2020",
+      "module": "preserve",
+      "moduleResolution": "bundler",
+      "allowImportingTsExtensions": true,
+      "noEmit": true,
 
       // additional recommended configuration
-      lib: ["ES2020", "DOM", "DOM.Iterable"],
-      verbatimModuleSyntax: true,
-      erasableSyntaxOnly: true,
+      "lib": ["ES2020", "DOM", "DOM.Iterable"],
+      "verbatimModuleSyntax": true,
+      "erasableSyntaxOnly": true,
     },
 
-    exclude: ["./public/", "./greenwood/", "node_modules"],
+    "exclude": ["./public/", "./greenwood/", "node_modules"],
   }
   ```
 

--- a/src/pages/docs/resources/typescript.md
+++ b/src/pages/docs/resources/typescript.md
@@ -25,25 +25,25 @@ The below steps will help you get up and running with TypeScript in your Greenwo
 
 <app-ctc-block variant="snippet" heading="tsconfig.json">
 
-```json5
-{
-  compilerOptions: {
-    // minimum required configuration
-    target: "es2020",
-    module: "preserve",
-    moduleResolution: "bundler",
-    allowImportingTsExtensions: true,
-    noEmit: true,
+  ```json5
+  {
+    compilerOptions: {
+      // minimum required configuration
+      target: "es2020",
+      module: "preserve",
+      moduleResolution: "bundler",
+      allowImportingTsExtensions: true,
+      noEmit: true,
 
-    // additional recommended configuration
-    lib: ["ES2020", "DOM", "DOM.Iterable"],
-    verbatimModuleSyntax: true,
-    erasableSyntaxOnly: true,
-  },
+      // additional recommended configuration
+      lib: ["ES2020", "DOM", "DOM.Iterable"],
+      verbatimModuleSyntax: true,
+      erasableSyntaxOnly: true,
+    },
 
-  exclude: ["./public/", "./greenwood/", "node_modules"],
-}
-```
+    exclude: ["./public/", "./greenwood/", "node_modules"],
+  }
+  ```
 
 </app-ctc-block>
 

--- a/src/pages/docs/resources/typescript.md
+++ b/src/pages/docs/resources/typescript.md
@@ -14,26 +14,34 @@ Greenwood provides built-in support for TypeScript, either through type-strippin
 
 ## Setup
 
-The below steps will help you get up and running with TypeScript in your Greenwood project. The general recommendation is to use type-stripping during development for faster live reload, and then run TypeScript during CI (e.g. GitHub Actions) to check and enforce all types, e.g. `tsc --project tsconfig.json`.
+The below steps will help you get up and running with TypeScript in your Greenwood project, and are the [same settings](https://github.com/ProjectEvergreen/greenwood/blob/master/packages/init/src/template-base-ts/tsconfig.json) you'll get running [Greenwood's **init** package with TypeScript enabled](/docs/introduction/setup/#init). The general recommendation is to use type-stripping during development for faster live reload, and then run TypeScript during CI (e.g. GitHub Actions) to check and enforce all types, e.g. `tsc --project tsconfig.json`.
 
 1. You will need to use Node **>= 22.6.0** and set the `--experimental-strip-types` flag
 1. Install TypeScript into your project, e.g. `npm i typescript --save-dev`
-1. Create a _tsconfig.json_ file at the root of your project with these minimum configuration settings. We also recommend adding the [`erasableSyntaxOnly` setting](https://www.typescriptlang.org/tsconfig/#erasableSyntaxOnly)
+1. Create a _tsconfig.json_ file at the root of your project with the below minimum configuration settings.
+1. We also recommend additional configurations like [`verbatimModuleSyntax`](https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax) and [`erasableSyntaxOnly` setting](https://www.typescriptlang.org/tsconfig/#erasableSyntaxOnly)
 
   <!-- prettier-ignore-start -->
 
   <app-ctc-block variant="snippet" heading="tsconfig.json">
 
-```json
+```json5
 {
-  "compilerOptions": {
-    "target": "es2015",
-    "module": "preserve",
-    "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
-    "verbatimModuleSyntax": false,
-    "noEmit": true
-  }
+  compilerOptions: {
+    // minimum required configuration
+    target: "es2020",
+    module: "preserve",
+    moduleResolution: "bundler",
+    allowImportingTsExtensions: true,
+    noEmit: true,
+
+    // additional recommended configuration
+    lib: ["ES2020", "DOM", "DOM.Iterable"],
+    verbatimModuleSyntax: true,
+    erasableSyntaxOnly: true,
+  },
+
+  exclude: ["./public/", "./greenwood/", "node_modules"],
 }
 ```
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

resolves #219 

## Summary of Changes

1. Recommend minimum setting for `target` in _tsconfig.json_
1. Recommendation for importing `type`s

## TODO
1. [x] Bump to `es2020` - https://github.com/ProjectEvergreen/greenwood/pull/1516#discussion_r2167806256
1. [x] Account for `verbatimModuleSyntax` and `erasableSyntaxOnly` - https://github.com/ProjectEvergreen/greenwood/pull/1520#pullrequestreview-2960152895
1. [x] _tsconfig.json_ keys need to be quoted
1. [x] `es2015` minimum callout / comment (for `class` support)
1. [x] call out for importing `type` recommendations - https://github.com/ProjectEvergreen/greenwood/issues/1576