### PR TITLE
enhancement/issue 220 open all external links in a new browser tab

### DIFF
--- a/greenwood.config.js
+++ b/greenwood.config.js
@@ -53,6 +53,8 @@ export default {
           // https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a#security_and_privacy
           rel: ["nofollow", "noopener", "noreferrer"],
           target: "_blank",
+          contentProperties: { className: ["no-show-screen-reader"] },
+          content: [{ type: "text", value: " (opens in a new window)" }],
         },
       },
     ],

--- a/greenwood.config.js
+++ b/greenwood.config.js
@@ -55,6 +55,7 @@ export default {
           target: "_blank",
           contentProperties: { className: ["no-show-screen-reader"] },
           content: [{ type: "text", value: " (opens in a new window)" }],
+          properties: { className: ["external-link-icon"] },
         },
       },
     ],

--- a/greenwood.config.js
+++ b/greenwood.config.js
@@ -47,6 +47,14 @@ export default {
       "rehype-autolink-headings",
       "remark-github",
       "remark-gfm",
+      {
+        name: "rehype-external-links",
+        options: {
+          // https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a#security_and_privacy
+          rel: ["nofollow", "noopener", "noreferrer"],
+          target: "_blank",
+        },
+      },
     ],
   },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "node-html-parser": "^6.1.13",
         "prettier": "^3.2.5",
         "rehype-autolink-headings": "^4.0.0",
+        "rehype-external-links": "^3.0.0",
         "rehype-slug": "^3.0.0",
         "remark-gfm": "^4.0.0",
         "remark-github": "^10.0.1",
@@ -15142,6 +15143,8 @@
     },
     "node_modules/rehype-external-links": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-external-links/-/rehype-external-links-3.0.0.tgz",
+      "integrity": "sha512-yp+e5N9V3C6bwBeAC4n796kc86M4gJCdlVhiMTxIrJG5UHDMh+PJANf9heqORJbt1nrCbDwIlAZKjANIaVBbvw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "node-html-parser": "^6.1.13",
     "prettier": "^3.2.5",
     "rehype-autolink-headings": "^4.0.0",
+    "rehype-external-links": "^3.0.0",
     "rehype-slug": "^3.0.0",
     "remark-gfm": "^4.0.0",
     "remark-github": "^10.0.1",

--- a/src/assets/external-link.svg
+++ b/src/assets/external-link.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="16px" height="16px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g>
+    <path id="Vector" d="M10.0002 5H8.2002C7.08009 5 6.51962 5 6.0918 5.21799C5.71547 5.40973 5.40973 5.71547 5.21799 6.0918C5 6.51962 5 7.08009 5 8.2002V15.8002C5 16.9203 5 17.4801 5.21799 17.9079C5.40973 18.2842 5.71547 18.5905 6.0918 18.7822C6.5192 19 7.07899 19 8.19691 19H15.8031C16.921 19 17.48 19 17.9074 18.7822C18.2837 18.5905 18.5905 18.2839 18.7822 17.9076C19 17.4802 19 16.921 19 15.8031V14M20 9V4M20 4H15M20 4L13 11" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+</svg>

--- a/src/components/get-started/get-started.js
+++ b/src/components/get-started/get-started.js
@@ -17,6 +17,7 @@ export default class GetStarted extends HTMLElement {
         <div>
           <a href="https://stackblitz.com/github/projectevergreen/greenwood-getting-started" class="${styles.buttonBlitz}" target="_blank">
             <span>View in Stackblitz</span>
+            <span class="no-show-screen-reader"> (opens in a new window)</span>
           </a>
           
           <a href="/guides/getting-started/" class="${styles.buttonStarted}">

--- a/src/components/get-started/get-started.js
+++ b/src/components/get-started/get-started.js
@@ -15,7 +15,7 @@ export default class GetStarted extends HTMLElement {
         </div>
 
         <div>
-          <a href="https://stackblitz.com/github/projectevergreen/greenwood-getting-started" class="${styles.buttonBlitz}">
+          <a href="https://stackblitz.com/github/projectevergreen/greenwood-getting-started" class="${styles.buttonBlitz}" target="_blank">
             <span>View in Stackblitz</span>
           </a>
           

--- a/src/components/hero-banner/hero-banner.js
+++ b/src/components/hero-banner/hero-banner.js
@@ -14,6 +14,7 @@ export default class HeroBanner extends HTMLElement {
         <div class="${styles.ctaContainer}">
           <a href="https://stackblitz.com/github/projectevergreen/greenwood-getting-started" class="${styles.buttonBlitz}"  target="_blank">
             <span>View in Stackblitz</span>
+            <span class="no-show-screen-reader"> (opens in a new window)</span>
           </a>
           
           <a href="/guides/getting-started/" class="${styles.buttonStarted}">

--- a/src/components/hero-banner/hero-banner.js
+++ b/src/components/hero-banner/hero-banner.js
@@ -12,7 +12,7 @@ export default class HeroBanner extends HTMLElement {
         <p class="${styles.headingSub}">Greenwood is your workbench for the web, embracing web standards from the ground up to empower your stack from front to back.</p>
 
         <div class="${styles.ctaContainer}">
-          <a href="https://stackblitz.com/github/projectevergreen/greenwood-getting-started" class="${styles.buttonBlitz}">
+          <a href="https://stackblitz.com/github/projectevergreen/greenwood-getting-started" class="${styles.buttonBlitz}"  target="_blank">
             <span>View in Stackblitz</span>
           </a>
           

--- a/src/components/social-tray/social-tray.js
+++ b/src/components/social-tray/social-tray.js
@@ -9,25 +9,25 @@ export default class SocialTray extends HTMLElement {
     this.innerHTML = `
       <ul class="${styles.socialTray}">
         <li class="${styles.socialIcon}">
-          <a href="https://github.com/ProjectEvergreen/greenwood" title="GitHub">
+          <a href="https://github.com/ProjectEvergreen/greenwood" title="GitHub" target="_blank">
             ${githubIcon}
           </a>
         </li>
 
         <li class="${styles.socialIcon}">
-          <a href="/discord/" title="Discord">
+          <a href="/discord/" title="Discord" target="_blank">
             ${discordIcon}
           </a>
         </li>
 		
         <li class="${styles.socialIcon}">
-          <a href="https://bsky.app/profile/projectevergreen.bsky.social" title="BlueSky">
+          <a href="https://bsky.app/profile/projectevergreen.bsky.social" title="BlueSky" target="_blank">
             ${blueskyIcon}
           </a>
         </li>
 
         <li class="${styles.socialIcon}">
-          <a href="https://twitter.com/PrjEvergreen" title="Twitter">
+          <a href="https://twitter.com/PrjEvergreen" title="Twitter" target="_blank">
             ${twitterIcon}
           </a>
         </li>

--- a/src/components/social-tray/social-tray.js
+++ b/src/components/social-tray/social-tray.js
@@ -11,24 +11,28 @@ export default class SocialTray extends HTMLElement {
         <li class="${styles.socialIcon}">
           <a href="https://github.com/ProjectEvergreen/greenwood" title="GitHub" target="_blank">
             ${githubIcon}
+            <span class="no-show-screen-reader"> (opens in a new window)</span>
           </a>
         </li>
 
         <li class="${styles.socialIcon}">
           <a href="/discord/" title="Discord" target="_blank">
             ${discordIcon}
+            <span class="no-show-screen-reader"> (opens in a new window)</span>
           </a>
         </li>
 		
         <li class="${styles.socialIcon}">
           <a href="https://bsky.app/profile/projectevergreen.bsky.social" title="BlueSky" target="_blank">
             ${blueskyIcon}
+            <span class="no-show-screen-reader"> (opens in a new window)</span>
           </a>
         </li>
 
         <li class="${styles.socialIcon}">
           <a href="https://twitter.com/PrjEvergreen" title="Twitter" target="_blank">
             ${twitterIcon}
+            <span class="no-show-screen-reader"> (opens in a new window)</span>
           </a>
         </li>
       </ul>

--- a/src/components/social-tray/social-tray.spec.js
+++ b/src/components/social-tray/social-tray.spec.js
@@ -40,9 +40,11 @@ describe("Components/Social Tray", () => {
     it("should have the expected social link icons", () => {
       const links = tray.querySelectorAll("ul li a");
       const icons = tray.querySelectorAll("ul li a svg");
+      const noShowScreenReader = tray.querySelectorAll("ul li a span.no-show-screen-reader");
 
       expect(links.length).to.equal(4);
       expect(icons.length).to.equal(4);
+      expect(noShowScreenReader.length).to.equal(4);
 
       Array.from(links).forEach((link) => {
         const iconItem = ICONS.find((icon) => icon.title === link.getAttribute("title"));

--- a/src/components/social-tray/social-tray.spec.js
+++ b/src/components/social-tray/social-tray.spec.js
@@ -49,6 +49,7 @@ describe("Components/Social Tray", () => {
 
         expect(iconItem).to.not.equal(undefined);
         expect(link.getAttribute("href")).to.equal(iconItem.link);
+        expect(link.getAttribute("target")).equal("_blank");
       });
     });
   });

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -145,6 +145,7 @@ li {
   }
 }
 
+/* external links styling */
 .no-show-screen-reader {
   clip: rect(0 0 0 0);
   clip-path: inset(50%);
@@ -153,4 +154,10 @@ li {
   position: absolute;
   white-space: nowrap;
   width: 1px;
+}
+
+.external-link-icon::after {
+  content: url(/assets/external-link.svg);
+  margin: 0 0 0 var(--size-1);
+  vertical-align: middle;
 }

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -144,3 +144,13 @@ li {
     font-style: italic;
   }
 }
+
+.no-show-screen-reader {
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

resolves #220

## Summary of Changes

1. Update all external site links to open in a new browser tab
1. Added [**rehype-external-links**](https://github.com/rehypejs/rehype-external-links) plugin to automatically setup external links in markdown
1. Add external link icon to external links

<img width="1514" height="789" alt="Screenshot 2025-08-01 at 10 00 43 AM" src="https://github.com/user-attachments/assets/5d0698d7-a652-4e0c-bae5-235578c3731d" />


## TODO
1. [x] Update all markdown links
1. [x] Add test cases where applicable
1. [x] a11y feedback - https://github.com/ProjectEvergreen/www.greenwoodjs.dev/pull/221/files#r2211824607
1. [x] some kind of icon to indicate markdown links are external (nice to have)