### PR TITLE
docs: refine CSS Modules type

### DIFF
--- a/src/pages/docs/plugins/css-modules.md
+++ b/src/pages/docs/plugins/css-modules.md
@@ -158,8 +158,8 @@ To support typing of `.module.css` imports, you can add this type definition to 
 
 ```ts
 declare module "*.module.css" {
-  const styles: { [className: string]: string };
-  export default styles;
+  const classes: Readonly<Record<string, string>>;
+  export default classes;
 }
 ```
 

--- a/src/pages/docs/plugins/css-modules.md
+++ b/src/pages/docs/plugins/css-modules.md
@@ -158,8 +158,8 @@ To support typing of `.module.css` imports, you can add this type definition to 
 
 ```ts
 declare module "*.module.css" {
-  const classes: Readonly<Record<string, string>>;
-  export default classes;
+  const styles: Readonly<Record<string, string>>;
+  export default styles;
 }
 ```
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

N / A

> related docs - https://greenwoodjs.dev/docs/plugins/css-modules/

## Summary of Changes

1. Use `Readonly`
1. Use `Record` - https://www.typescriptlang.org/docs/handbook/utility-types.html#recordkeys-type ?

## TODO
1. [x] Is there a community consensus?  (something in the CSS Modules repo?) - https://github.com/ProjectEvergreen/greenwood/pull/1537#issuecomment-3240521589