### PR TITLE
docs: #226 document new minimum NodeJS version 22.18.0

### DIFF
--- a/src/pages/docs/introduction/setup.md
+++ b/src/pages/docs/introduction/setup.md
@@ -8,6 +8,8 @@ tocHeading: 2
 
 Greenwood has a few options for getting a new project started. You can also check out our [_Getting Started_ guide](/guides/getting-started/) for a full walk-through of creating a simple blog site with Greenwood.
 
+Greenwood supports NodeJS LTS version >= 22.18.0.
+
 ## Init
 
 The recommended way to start a new Greenwood project, our **init** CLI will scaffold out a starter project for you. Just run a single command and then follow the prompts. Make sure you have the [latest LTS version of Node](https://nodejs.org/en/download) installed.

--- a/src/pages/docs/introduction/setup.md
+++ b/src/pages/docs/introduction/setup.md
@@ -89,3 +89,32 @@ The CLI supports three commands, that can be easily mapped to npm scripts in you
 </app-ctc-block>
 
 <!-- prettier-ignore-end -->
+
+## Troubleshooting
+
+### Rollup Linux x64 GNU
+
+<!-- if / when Greenwood bumps up Node 24, we can remove this message -->
+
+If using npm, depending on the version, if you see an error like this in GitHub Actions or any hosting provider:
+
+```shell
+Error: Cannot find module @rollup/rollup-linux-x64-gnu. npm has a bug related to optional dependencies (https://github.com/npm/cli/issues/4828). Please try `npm i` again after removing both package-lock.json and node_modules directory.
+```
+
+Add [**@rollup/rollup-linux-x64-gnu**](https://www.npmjs.com/package/@rollup/rollup-linux-x64-gnu) as an [optional dependency to your _package.json_](https://stackoverflow.com/questions/79048814/github-action-is-failing-due-to-rollup-rollup-linux-x64-gnu):
+
+<!-- prettier-ignore-start -->
+<app-ctc-block variant="snippet" heading="package.json">
+
+  ```json
+  {
+    "optionalDependencies": {
+      "@rollup/rollup-linux-x64-gnu": "^4.50.0"
+    }
+  }
+  ```
+
+</app-ctc-block>
+
+<!-- prettier-ignore-end -->

--- a/src/pages/docs/resources/typescript.md
+++ b/src/pages/docs/resources/typescript.md
@@ -16,7 +16,7 @@ Greenwood provides built-in support for TypeScript, either through type-strippin
 
 The below steps will help you get up and running with TypeScript in your Greenwood project, and are the [same settings](https://github.com/ProjectEvergreen/greenwood/blob/master/packages/init/src/template-base-ts/tsconfig.json) you'll get running [Greenwood's **init** package with TypeScript enabled](/docs/introduction/setup/#init). The general recommendation is to use type-stripping during development for faster live reload, and then run TypeScript during CI (e.g. GitHub Actions) to check and enforce all types, e.g. `tsc --project tsconfig.json`.
 
-1. You will need to use Node **>= 22.6.0** and set the `--experimental-strip-types` flag
+1. You will need to use Node LTS **>= 22.18.0**
 1. Install TypeScript into your project, e.g. `npm i typescript --save-dev`
 1. Create a _tsconfig.json_ file at the root of your project with the below minimum configuration settings.
 1. We also recommend additional configurations like [`verbatimModuleSyntax`](https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax) and [`erasableSyntaxOnly` setting](https://www.typescriptlang.org/tsconfig/#erasableSyntaxOnly)
@@ -48,8 +48,6 @@ The below steps will help you get up and running with TypeScript in your Greenwo
 </app-ctc-block>
 
 <!-- prettier-ignore-end -->
-
-> _If you're feeling adventurous, you can use **>=23.x** and omit the `--experimental-strip-types` flag_. Keep an eye on [this PR](https://github.com/nodejs/node/pull/57298) for when unflagged type-stripping support may come to Node LTS **22.x**. 👀
 
 ## Types
 

--- a/src/pages/docs/resources/typescript.md
+++ b/src/pages/docs/resources/typescript.md
@@ -16,7 +16,6 @@ Greenwood provides built-in support for TypeScript, either through type-strippin
 
 The below steps will help you get up and running with TypeScript in your Greenwood project, and are the [same settings](https://github.com/ProjectEvergreen/greenwood/blob/master/packages/init/src/template-base-ts/tsconfig.json) you'll get running [Greenwood's **init** package with TypeScript enabled](/docs/introduction/setup/#init). The general recommendation is to use type-stripping during development for faster live reload, and then run TypeScript during CI (e.g. GitHub Actions) to check and enforce all types, e.g. `tsc --project tsconfig.json`.
 
-1. You will need to use Node LTS **>= 22.18.0**
 1. Install TypeScript into your project, e.g. `npm i typescript --save-dev`
 1. Create a _tsconfig.json_ file at the root of your project with the below minimum configuration settings.
 1. We also recommend additional configurations like [`verbatimModuleSyntax`](https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax) and [`erasableSyntaxOnly` setting](https://www.typescriptlang.org/tsconfig/#erasableSyntaxOnly)

--- a/src/pages/guides/getting-started/index.md
+++ b/src/pages/guides/getting-started/index.md
@@ -20,8 +20,8 @@ This _Getting Started_ guide will walk you through creating a basic static conte
 
 You will need the following installed on your machine:
 
-1. Latest [**NodeJS LTS**](https://nodejs.org/en/download) (required) - We recommend using a Node version manager (like NVM) to install the latest stable version of Node
-1. [**Git**](https://git-scm.com/) (optional) - Can be useful for [cloning and inspecting](https://github.com/ProjectEvergreen/greenwood-getting-started) the companion repo for this guide, or otherwise managing your Greenwood project through version control
+1. Latest [**NodeJS LTS**](https://nodejs.org/en/download) version (required) - We recommend using a Node version manager (like [**NVM**](https://github.com/nvm-sh/nvm)) to manage local node installations.
+1. [**Git**](https://git-scm.com/) (optional) - Can be useful for [cloning and inspecting](https://github.com/ProjectEvergreen/greenwood-getting-started) the companion repo for this guide, or otherwise managing your Greenwood project through version control.
 
 You can verify that NodeJS has been installed correctly by checking its version from the command line:
 

--- a/src/pages/guides/getting-started/index.md
+++ b/src/pages/guides/getting-started/index.md
@@ -85,9 +85,11 @@ Then setup some npm scripts in your _package.json_ for running Greenwood and mak
 
 <!-- prettier-ignore-end -->
 
-## Jump Right In
+## Stackblitz
 
 If you want to jump to the final results right away, you can browse [the companion repo](https://github.com/ProjectEvergreen/greenwood-getting-started) or play around with it directly in your browser on [Stackblitz](https://stackblitz.com/github/projectevergreen/greenwood-getting-started).
+
+> ⚠️ Currently Stackblitz does [not have support for Node `22.18.0`](https://github.com/stackblitz/webcontainer-core/issues/560#issuecomment-3263215295).
 
 <iframe class="stackblitz" src="https://stackblitz.com/github/projectevergreen/greenwood-getting-started?embed=1" loading="lazy"></iframe>
 

--- a/src/pages/guides/getting-started/index.md
+++ b/src/pages/guides/getting-started/index.md
@@ -85,13 +85,16 @@ Then setup some npm scripts in your _package.json_ for running Greenwood and mak
 
 <!-- prettier-ignore-end -->
 
-## Stackblitz
+<!-- Looking for Stackblitz alternatives -->
+<!-- https://github.com/ProjectEvergreen/www.greenwoodjs.dev/discussions/248 -->
+
+<!-- ## Jump Right In
 
 If you want to jump to the final results right away, you can browse [the companion repo](https://github.com/ProjectEvergreen/greenwood-getting-started) or play around with it directly in your browser on [Stackblitz](https://stackblitz.com/github/projectevergreen/greenwood-getting-started).
 
-> ⚠️ Currently Stackblitz does [not have support for Node `22.18.0`](https://github.com/stackblitz/webcontainer-core/issues/560#issuecomment-3263215295).
-
 <iframe class="stackblitz" src="https://stackblitz.com/github/projectevergreen/greenwood-getting-started?embed=1" loading="lazy"></iframe>
+
+-->
 
 ## Next Section
 

--- a/src/pages/guides/getting-started/index.md
+++ b/src/pages/guides/getting-started/index.md
@@ -20,14 +20,14 @@ This _Getting Started_ guide will walk you through creating a basic static conte
 
 You will need the following installed on your machine:
 
-1. [**NodeJS LTS**](https://nodejs.org/en/download) (required) - We recommend using a Node version manager (like NVM) to install the latest stable version of Node
+1. Latest [**NodeJS LTS**](https://nodejs.org/en/download) (required) - We recommend using a Node version manager (like NVM) to install the latest stable version of Node
 1. [**Git**](https://git-scm.com/) (optional) - Can be useful for [cloning and inspecting](https://github.com/ProjectEvergreen/greenwood-getting-started) the companion repo for this guide, or otherwise managing your Greenwood project through version control
 
 You can verify that NodeJS has been installed correctly by checking its version from the command line:
 
 ```bash
 $ node -v
-v22.13.0
+v22.18.0
 ```
 
 ## Setup


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

resolves #226

## Summary of Changes

1. document new minimum NodeJS version 22.18.0
1. update TypeScript / NodeJS version callouts
1. ~~Call~~ Comment out [(lack of) Stackblitz support for Node 22](https://github.com/stackblitz/webcontainer-core/issues/560#issuecomment-3263215295)
1. Add **Troubleshooting** section to _Setup_ guide with callout for optional Rollup dependency

## TODO
1. [x] Let's comment out Stackblits for now and open a discussion on alternatives - https://github.com/ProjectEvergreen/www.greenwoodjs.dev/discussions/248