### PR TITLE
docs: #227 add CLI reference documentation page

### DIFF
--- a/src/pages/docs/reference/appendix.md
+++ b/src/pages/docs/reference/appendix.md
@@ -1,6 +1,6 @@
 ---
 layout: docs
-order: 4
+order: 5
 tocHeading: 2
 ---
 

--- a/src/pages/docs/reference/cli.md
+++ b/src/pages/docs/reference/cli.md
@@ -1,0 +1,43 @@
+---
+layout: docs
+title: CLI
+label: CLI
+order: 3
+tocHeading: 2
+---
+
+# CLI
+
+Although the most common way to interact with Greenwood is through [npm scripts in your _package.json_](/docs/introduction/setup/#commands), it is also possible to interact with the CLI programmatically in JavaScript.
+
+## Commands
+
+You can see all available commands by passing the `--help` flag to the CLI entrypoint:
+
+```shell
+$ ./node_modules/.bin/greenwood --help
+-------------------------------------------------------
+Welcome to Greenwood (v0.33.0) ♻️
+-------------------------------------------------------
+
+Usage: greenwood <command>
+
+Options:
+  -h, --help       Show help information
+  -V, --version    Show version number
+
+Commands:
+  build            Generate a production build.
+  develop          Start a local development server.
+  serve            Start a production server.
+```
+
+## Usage
+
+For interactive usage, you can import the CLI and call the `run` function with either the **build**, **develop**, or **serve** commands.
+
+```js
+import { run } from "@greenwood/cli/src/index.js";
+
+run("build");
+```

--- a/src/pages/docs/reference/cli.md
+++ b/src/pages/docs/reference/cli.md
@@ -34,7 +34,7 @@ Commands:
 
 ## Usage
 
-For interactive usage, you can import the CLI and call the `run` function with either the **build**, **develop**, or **serve** commands.
+For programmatic usage, you can import the CLI and call the `run` function with either the **build**, **develop**, or **serve** commands.
 
 ```js
 import { run } from "@greenwood/cli/src/index.js";

--- a/src/pages/docs/reference/index.md
+++ b/src/pages/docs/reference/index.md
@@ -11,5 +11,6 @@ The content is broken down across these sections:
 
 - [Configuration](/docs/reference/configuration/) - All of Greenwood's configuration options
 - [Plugins API](/docs/reference/plugins-api/) - Learn how to create your own plugins
+- [CLI](/docs/reference/cli/) - Interacting with the Greenwood CLI programmatically
 - [Rendering Strategies](/docs/reference/rendering-strategies/) - Techniques and tips for various rendering options like CSR, SSR, and prerendering
 - [Appendix](/docs/reference/appendix/) - Supplemental topics like Greenwood's build output, internal build state, and DOM emulation handling

--- a/src/pages/docs/reference/rendering-strategies.md
+++ b/src/pages/docs/reference/rendering-strategies.md
@@ -1,6 +1,6 @@
 ---
 layout: docs
-order: 3
+order: 4
 tocHeading: 2
 ---
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

resolves #227 

## Summary of Changes

1. Add a reference documentation page for the CLI

<img width="430" height="321" alt="Screenshot 2025-09-01 at 4 17 57 PM" src="https://github.com/user-attachments/assets/bab39ad4-ecd0-4210-be56-86198ea7784d" />