### PR TITLE
bug(docs): #243 fix classname for stackblitz show embed styles

### DIFF
--- a/src/styles/docs.css
+++ b/src/styles/docs.css
@@ -166,8 +166,9 @@ app-side-nav {
 }
 
 @media (min-width: 768px) {
-  .page-content {
+  .page-content .content-outlet {
     & iframe.stackblitz {
+      margin: 10px 0;
       width: 100%;
       height: 800px;
       display: block;


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

resolves #243 

## Summary of Changes

1. Fix styles for when to show Stackblitz `<iframe>` embed

<img width="1491" height="895" alt="Screenshot 2025-09-08 at 8 42 56 PM" src="https://github.com/user-attachments/assets/3a3cf820-3261-4fcf-8198-7793f878ca5d" />

----

However, this pesky problem "returns" now
- https://github.com/ProjectEvergreen/greenwood/issues/797
- https://github.com/stackblitz/core/issues/1653

But, in #233 , it's not even going to be supported?  Maybe we should just hide the whole thing?