### PR TITLE
enhancement: use `cursor: copy` for copy to clipboard interaction buttons

### DIFF
--- a/src/components/copy-to-clipboard-block/ctc-block.css
+++ b/src/components/copy-to-clipboard-block/ctc-block.css
@@ -43,7 +43,7 @@
     right: 10px;
     width: 40px;
     vertical-align: middle;
-    cursor: pointer;
+    cursor: copy;
   }
 
   & .copy-icon svg {
@@ -63,7 +63,7 @@
     right: 10px;
     width: 40px;
     vertical-align: middle;
-    cursor: pointer;
+    cursor: copy;
   }
 
   & .copy-icon svg {
@@ -109,7 +109,7 @@
     right: 10px;
     width: 40px;
     vertical-align: middle;
-    cursor: pointer;
+    cursor: copy;
   }
 
   & .copy-icon svg {

--- a/src/components/copy-to-clipboard-button/ctc-button.css
+++ b/src/components/copy-to-clipboard-button/ctc-button.css
@@ -1,7 +1,7 @@
 #icon {
   padding: var(--size-2);
   border: none;
-  cursor: pointer;
+  cursor: copy;
   border-radius: var(--radius-3);
   background-color: var(--color-green-pale);
 }


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

N / A

## Summary of Changes

1. Change copy to clipboard related interactions to use [`cursor: copy`](https://www.w3schools.com/cssref/playit.php?filename=playcss_cursor&preval=copy)

## TODO
1. [x] Check all browsers