### PR TITLE
docs: update shoelace name on lit ecosystem page

### DIFF
--- a/src/pages/guides/ecosystem/lit.md
+++ b/src/pages/guides/ecosystem/lit.md
@@ -9,7 +9,10 @@ tocHeading: 2
 
 [**Lit**](https://lit.dev/) builds on top of the Web Components standards, adding additional developer experience ergonomics like reactivity, declarative templates and reducing boilerplate. Lit also has support for SSR (server-side rendering), which Greenwood supports through a plugin.
 
-> You can see a complete hybrid project example in this [demonstration repo](https://github.com/thescientist13/greenwood-lit-ssr) as well as [demos](https://github.com/thescientist13/greenwood-lit-ssr/pulls?q=is%3Apr+is%3Aopen+label%3Ademo) of using Lit based component libraries like [**Shoelace**](https://shoelace.style/) and [**Spectrum Web Components**](https://opensource.adobe.com/spectrum-web-components/) with Greenwood.
+> You can see a complete hybrid project example in this [demonstration repo](https://github.com/thescientist13/greenwood-lit-ssr) as well as [demos](https://github.com/thescientist13/greenwood-lit-ssr/pulls?q=is%3Apr+is%3Aopen+label%3Ademo) of using Lit based component libraries, like:
+>
+> - [**Web Awesome (formerly Shoelace)**](https://github.com/thescientist13/greenwood-lit-ssr/tree/web-awesome)
+> - [**Spectrum Web Components**](https://github.com/thescientist13/greenwood-lit-ssr/tree/demo-spectrum)
 
 ## Installation
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

N / A

## Summary of Changes

1. Shoelace has been Web Awesome for a [little while now](https://blog.fontawesome.com/introducing-web-awesome/) 😅 
1. Tweak the callout links a bit

<img width="1047" height="521" alt="Screenshot 2026-06-26 at 9 16 01 PM" src="https://github.com/user-attachments/assets/b508bf6f-ebda-4851-b398-5b6ad0783167" />