### PR TITLE
docs: document typecript v7 and use tsc config caveat

### DIFF
--- a/src/pages/docs/reference/configuration.md
+++ b/src/pages/docs/reference/configuration.md
@@ -439,7 +439,7 @@ Setting the `staticRouter` option to `true` will add a small router runtime in p
 
 ## Use TypeScript Compiler
 
-> ⚠️ This feature is currently not supported with TypeScript >= 7.x. Please follow along with [this issue](https://github.com/ProjectEvergreen/greenwood/issues/1702) for more information and to follow along with the work.
+> ⚠️ This feature is currently not supported with TypeScript >= 7.x. Please see [this issue](https://github.com/ProjectEvergreen/greenwood/issues/1702) for more information and to follow along with the work.
 
 Depending on the TypeScript features / JavaScript syntax you're using, you may need more then just Greenwood's default capability of only type _stripping_. For these cases where you want to use the full TypeScript compiler for transpilation, you'll want to [setup TypeScript for Greenwood](/docs/resources/typescript/) and set the `useTsc` flag.
 

--- a/src/pages/docs/reference/configuration.md
+++ b/src/pages/docs/reference/configuration.md
@@ -439,11 +439,13 @@ Setting the `staticRouter` option to `true` will add a small router runtime in p
 
 ## Use TypeScript Compiler
 
+> ⚠️ This feature is currently not supported with TypeScript >= 7.x. Please follow along with [this issue](https://github.com/ProjectEvergreen/greenwood/issues/1702) for more information and to follow along with the work.
+
 Depending on the TypeScript features / JavaScript syntax you're using, you may need more then just Greenwood's default capability of only type _stripping_. For these cases where you want to use the full TypeScript compiler for transpilation, you'll want to [setup TypeScript for Greenwood](/docs/resources/typescript/) and set the `useTsc` flag.
 
 <!-- prettier-ignore-start -->
 
-<app-ctc-block variant="snippet">
+<app-ctc-block variant="snippet" heading="greenwood.config.ts">
 
   ```js
   export default {


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

- https://github.com/ProjectEvergreen/greenwood/issues/1702
- https://github.com/ProjectEvergreen/greenwood/pull/1703

## Summary of Changes

1. document TypScript v7 and `useTsc` config caveat